### PR TITLE
Npm scripts improvements

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -81,13 +81,13 @@ You have to generate tile schema using `npm start schemata:make-tile {tiles path
 E.g. `npm start schemata:make-tile core/htmlTile HtmlTileConf`.
 
 Second, update your app's configuration - i.e. at least define a tile instance and put it in the layout.
-In tile configuration `tileType` is derived from tile folder name in the following way: 
+In tile configuration `tileType` is derived from tile folder name in the following way:
 `src/js/tiles/custom/myAwesome <---> MyAwesomeTile`.
 
-Third, build the project. 
+Third, build the project.
 
 ```
-npm start build:server && make start build:production
+npm start build:server && npm start build:production
 ```
 
 Now restart the server and the tile should appear on the page (based on the layout you've put the tile in).
@@ -109,11 +109,11 @@ It is also possible to generate your local version of the schemata and refer the
 local path.
 
 ```
-npm start schemata:make
+npm start schemata:make-conf
 ```
 
 You can always validate your configuration:
 
 ```
-make start schemata:configtest
+make start schemata:check-conf
 ```

--- a/launcher-config.json
+++ b/launcher-config.json
@@ -1,22 +1,20 @@
 {
   "scripts": {
-    "schemata:make-tiles": [
+    "schemata:make-core-tiles": [
       {
         "repeater": "$launch_setting_tiles",
-        "sequential": ["schemata:make-tile $_path $_conf_name"]
+        "sequential": "schemata:make-tile $_path $_conf_name"
       }
     ],
-    "schemata:make-tile": [
-      "typescript-json-schema src/js/tiles/$1/index.ts $2 --ignoreErrors --out src/js/tiles/$1/config-schema.json --required --strictNullChecks"
-    ],
-    "schemata:make": [
+    "schemata:make-tile": "ts-node ./scripts/create-tile-schema.ts $1 $2",
+    "schemata:make-conf": [
       "typescript-json-schema src/js/conf/index.ts ServerConf --ignoreErrors --out conf/server-schema.json --required --strictNullChecks",
       "typescript-json-schema src/js/conf/index.ts ClientStaticConf --ignoreErrors --out conf/wdglance-schema.json --required --strictNullChecks",
       "typescript-json-schema src/js/conf/index.ts LanguageLayoutsConfig --ignoreErrors --out conf/layouts-schema.json --required --strictNullChecks",
       "typescript-json-schema src/js/conf/index.ts LanguageAnyTileConf --ignoreErrors --out conf/tiles-schema.json --required --strictNullChecks",
       "typescript-json-schema src/js/conf/index.ts ColorsConf --ignoreErrors --out conf/themes-schema.json --required --strictNullChecks"
     ],
-    "schemata:configtest": [
+    "schemata:check-conf": [
       "ajv -s ./conf/server-schema.json -d ./conf/server.json",
       "ajv -s ./conf/wdglance-schema.json -d ./conf/wdglance.json",
       "LAYOUTS_PATH=\"$(node -pe 'JSON.parse(fs.readFileSync(\"conf/wdglance.json\", \"utf8\")).layouts')\"",
@@ -26,7 +24,7 @@
       "THEMES_PATH=\"$(node -pe 'JSON.parse(fs.readFileSync(\"conf/wdglance.json\", \"utf8\")).colors')\"",
       "if test -f \"$THEMES_PATH\" 2> /dev/null; then ajv -s ./conf/themes-schema.json -d $THEMES_PATH; else echo \"themes config file not found\"; fi"
     ],
-    "schemata:sampletest": [
+    "schemata:check-samples": [
       "ajv -s ./conf/server-schema.json -d ./conf/server.sample.json",
       "ajv -s ./conf/wdglance-schema.json -d ./conf/wdglance.sample.json"
     ],

--- a/launcher-config.json
+++ b/launcher-config.json
@@ -41,7 +41,10 @@
     ],
     "create:custom-tile": "ts-node ./scripts/create-tile.ts $1",
     "devel-server": "webpack-dev-server --config webpack.dev.js",
-    "server": "node dist-server/service.js",
+    "server": [
+      "ajv -s ./conf/server-schema.json -d ./conf/server.json",
+      "node dist-server/service.js"
+    ],
     "test": "npm test"
   },
   "settings": {

--- a/launcher-menu.json
+++ b/launcher-menu.json
@@ -2,10 +2,11 @@
   "menu": {
     "schemata:Config schemata actions menu...": {
       "description": "config schemata action",
-      "configtest:Tests config files": "schemata:configtest",
-      "sampletest:Tests sample config files": "schemata:sampletest",
-      "make:Generates config schemata": "schemata:make",
-      "make-tiles:Generates core tiles schemata": "schemata:make-tiles"
+      "check-conf:Tests config files": "schemata:check-conf",
+      "check-samples:Tests sample config files": "schemata:check-samples",
+      "make-conf:Generates config schemata": "schemata:make",
+      "make-tile:Generates schema for specified tile": "schemata:make-tile",
+      "make-core-tiles:Generates core tiles schemata": "schemata:make-core-tiles"
     },
     "build:Build menu...": {
       "description": "build action",
@@ -15,7 +16,7 @@
     },
     "create:Create menu...": {
       "custom-tile": "create:custom-tile"
-    },    
+    },
     "devel-server:starts a development server": "devel-server",
     "server:starts WaG web server": "server",
     "test:runs tests": "test"

--- a/scripts/create-tile-schema.ts
+++ b/scripts/create-tile-schema.ts
@@ -1,0 +1,52 @@
+const fs = require('fs');
+const path = require('path');
+const tjs = require("typescript-json-schema");
+
+
+const settings = {
+    ignoreErrors: true,
+    required: true
+};
+
+const compilerOptions = {
+    strictNullChecks: true
+}
+
+function generateSchema(tileDir:string, typeName:string) {
+    const basePath = path.resolve(__dirname, '../src/js/tiles');
+    const program = tjs.getProgramFromFiles([path.resolve(basePath, tileDir, 'index.ts')], compilerOptions);
+    const schema = tjs.generateSchema(program, typeName, settings);
+
+    fs.writeFile(
+        path.resolve(basePath, tileDir, 'config-schema.json'),
+        JSON.stringify(schema, undefined, 4),
+        'utf8',
+        err => {if (err) return console.log(err);}
+    );
+}
+
+
+if (process.argv.length === 4) {
+    generateSchema(process.argv[2], process.argv[3]);
+    console.log(`Config schema ${process.argv[2]} ${process.argv[3]} created!`);
+
+} else if (process.argv.length === 2) {
+    const readline = require('readline');
+    const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout
+    });
+
+    rl.question("Enter tile dir (e.g. core/html): ", tileDir => {
+        rl.question("Enter config type name (e.g. HtmlTileConf): ", typeName => {
+            generateSchema(tileDir, typeName);
+            rl.close();
+            console.log(`Config schema ${tileDir} ${typeName} created!`);
+        });
+    });
+
+} else {
+    console.error('Expected 2 arguments. Tile directory and config type name in index.ts!');
+    process.exit(1);
+}
+

--- a/scripts/create-tile.ts
+++ b/scripts/create-tile.ts
@@ -39,8 +39,8 @@ if (process.argv.length === 3) {
     createTile(process.argv[2]);
 
 } else if (process.argv.length === 2) {
-    let readline = require('readline');
-    let rl = readline.createInterface({
+    const readline = require('readline');
+    const rl = readline.createInterface({
         input: process.stdin,
         output: process.stdout
     });

--- a/scripts/create-tile.ts
+++ b/scripts/create-tile.ts
@@ -10,32 +10,47 @@ const templateFiles = [
     'views.tsx'
 ];
 
-let tileArg:string;
-if (process.argv.length === 3) {
-    tileArg = process.argv[2];
-} else {
-    console.error('Expected tile name argument!');
-    process.exit(1);
+function createTile(tileArg:string) {
+    const tileDir = tileArg[0].toLowerCase() + tileArg.slice(1);
+    const tileName = tileArg[0].toUpperCase() + tileArg.slice(1);
+
+    fs.mkdirSync(path.resolve(__dirname, '../src/js/tiles/custom', tileDir));
+    templateFiles.forEach(fileName => {
+        fs.readFile(
+            path.resolve(__dirname, 'template-tile', fileName),
+            'utf8',
+            (err, data) => {
+                if (err) return console.log(err);
+                fs.writeFile(
+                    path.resolve(__dirname, '../src/js/tiles/custom', tileDir, fileName),
+                    data.replace(/__Template__/g, tileName),
+                    'utf8',
+                    err => {if (err) return console.log(err);}
+                );
+            }
+        );
+    });
+
+    console.log(`Tile "${tileName}" created!`);
 }
 
-const tileDir = tileArg[0].toLowerCase() + tileArg.slice(1);
-const tileName = tileArg[0].toUpperCase() + tileArg.slice(1);
 
-fs.mkdirSync(path.resolve(__dirname, '../src/js/tiles/custom', tileDir));
-templateFiles.forEach(fileName => {
-    fs.readFile(
-        path.resolve(__dirname, 'template-tile', fileName),
-        'utf8',
-        (err, data) => {
-            if (err) return console.log(err);
-            fs.writeFile(
-                path.resolve(__dirname, '../src/js/tiles/custom', tileDir, fileName),
-                data.replace(/__Template__/g, tileName),
-                'utf8',
-                err => {if (err) return console.log(err);}
-            );
-        }
-    );
-});
+if (process.argv.length === 3) {
+    createTile(process.argv[2]);
 
-console.log(`Tile "${tileName}" created!`);
+} else if (process.argv.length === 2) {
+    let readline = require('readline');
+    let rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout
+    });
+
+    rl.question("Enter tile name: ", answer => {
+        createTile(answer);
+        rl.close();
+    });
+
+} else {
+    console.error('Expected one tile name argument!');
+    process.exit(1);
+}


### PR DESCRIPTION
- fix for issue #787 
- added interactive input for `create:custom-tile` and `schemata:make-tile` when no arguments provided