### PR TITLE
Derived layouts

### DIFF
--- a/conf/layouts-schema.json
+++ b/conf/layouts-schema.json
@@ -37,6 +37,9 @@
                 "tiles": {
                     "items": {
                         "properties": {
+                            "ref": {
+                                "type": "string"
+                            },
                             "tile": {
                                 "type": "string"
                             },
@@ -73,6 +76,36 @@
                         ]
                     },
                     "type": "array"
+                },
+                "insertAfter": {
+                    "additionalProperties": {
+                        "items": {
+                            "properties": {
+                                "tile": {
+                                    "type": "string"
+                                },
+                                "width": {
+                                    "type": "number"
+                                }
+                            },
+                            "required": [
+                                "tile",
+                                "width"
+                            ],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "type": "object"
+                },
+                "replace": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "type": "object"
+                },
+                "useLayout": {
+                    "type": "string"
                 }
             },
             "required": [
@@ -94,6 +127,36 @@
                         ]
                     },
                     "type": "array"
+                },
+                "insertAfter": {
+                    "additionalProperties": {
+                        "items": {
+                            "properties": {
+                                "tile": {
+                                    "type": "string"
+                                },
+                                "width": {
+                                    "type": "number"
+                                }
+                            },
+                            "required": [
+                                "tile",
+                                "width"
+                            ],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "type": "object"
+                },
+                "replace": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "type": "object"
+                },
+                "useLayout": {
+                    "type": "string"
                 }
             },
             "required": [
@@ -116,11 +179,41 @@
                     },
                     "type": "array"
                 },
+                "insertAfter": {
+                    "additionalProperties": {
+                        "items": {
+                            "properties": {
+                                "tile": {
+                                    "type": "string"
+                                },
+                                "width": {
+                                    "type": "number"
+                                }
+                            },
+                            "required": [
+                                "tile",
+                                "width"
+                            ],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "type": "object"
+                },
+                "replace": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "type": "object"
+                },
                 "targetDomains": {
                     "items": {
                         "type": "string"
                     },
                     "type": "array"
+                },
+                "useLayout": {
+                    "type": "string"
                 }
             },
             "required": [

--- a/conf/wdglance-schema.json
+++ b/conf/wdglance-schema.json
@@ -244,6 +244,9 @@
                 "tiles": {
                     "items": {
                         "properties": {
+                            "ref": {
+                                "type": "string"
+                            },
                             "tile": {
                                 "type": "string"
                             },
@@ -330,6 +333,36 @@
                         ]
                     },
                     "type": "array"
+                },
+                "insertAfter": {
+                    "additionalProperties": {
+                        "items": {
+                            "properties": {
+                                "tile": {
+                                    "type": "string"
+                                },
+                                "width": {
+                                    "type": "number"
+                                }
+                            },
+                            "required": [
+                                "tile",
+                                "width"
+                            ],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "type": "object"
+                },
+                "replace": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "type": "object"
+                },
+                "useLayout": {
+                    "type": "string"
                 }
             },
             "required": [
@@ -351,6 +384,36 @@
                         ]
                     },
                     "type": "array"
+                },
+                "insertAfter": {
+                    "additionalProperties": {
+                        "items": {
+                            "properties": {
+                                "tile": {
+                                    "type": "string"
+                                },
+                                "width": {
+                                    "type": "number"
+                                }
+                            },
+                            "required": [
+                                "tile",
+                                "width"
+                            ],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "type": "object"
+                },
+                "replace": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "type": "object"
+                },
+                "useLayout": {
+                    "type": "string"
                 }
             },
             "required": [
@@ -373,11 +436,41 @@
                     },
                     "type": "array"
                 },
+                "insertAfter": {
+                    "additionalProperties": {
+                        "items": {
+                            "properties": {
+                                "tile": {
+                                    "type": "string"
+                                },
+                                "width": {
+                                    "type": "number"
+                                }
+                            },
+                            "required": [
+                                "tile",
+                                "width"
+                            ],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "type": "object"
+                },
+                "replace": {
+                    "additionalProperties": {
+                        "type": "string"
+                    },
+                    "type": "object"
+                },
                 "targetDomains": {
                     "items": {
                         "type": "string"
                     },
                     "type": "array"
+                },
+                "useLayout": {
+                    "type": "string"
                 }
             },
             "required": [

--- a/src/js/conf/index.ts
+++ b/src/js/conf/index.ts
@@ -89,13 +89,16 @@ export interface GroupLayoutConfig {
     groupLabel:LocalizedConfMsg;
     groupDescURL?:LocalizedConfMsg;
     groupTemplate?:any; // TODO unfinished concept
-    tiles:Array<{tile:string; width:number}>;
+    tiles:Array<{tile:string; width:number; ref?:string}>;
 }
 
 export type GroupItemConfig = GroupLayoutConfig|string;
 
 export interface LayoutConfigCommon {
     groups:Array<GroupItemConfig>;
+    useLayout?:string;
+    replace?:{[ref:string]:string};
+    insertAfter?:{[ref:string]:Array<{tile:string; width:number}>};
 }
 
 export interface LayoutConfigSingleQuery extends LayoutConfigCommon {}

--- a/src/js/conf/loader.ts
+++ b/src/js/conf/loader.ts
@@ -20,7 +20,7 @@ import * as fs from 'fs';
 import axios from 'axios';
 import { pipe, List, Dict } from 'cnc-tskit';
 import * as path from 'path';
-import { DomainLayoutsConfig, DomainAnyTileConf, GroupItemConfig, TileDbConf } from './index';
+import { DomainLayoutsConfig, DomainAnyTileConf, GroupItemConfig, TileDbConf, LayoutsConfig, LayoutConfigSingleQuery, LayoutConfigCommon } from './index';
 import { TileConf } from '../page/tile';
 import { Observable, of as rxOf } from 'rxjs';
 import { reduce, mergeMap } from 'rxjs/operators';
@@ -125,4 +125,22 @@ export function loadRemoteTileConf(layout:DomainLayoutsConfig, tileDBConf:TileDb
     );
 
 
+}
+
+
+export function useCommonLayouts(layouts:DomainLayoutsConfig):DomainLayoutsConfig {
+    return Dict.map((queryTypes, domain) =>
+        Dict.map<LayoutConfigCommon, LayoutConfigCommon, string>((layout, queryType) =>
+            {
+                if (layout.useLayout) {
+                    const [d, qt] = layout.useLayout.split('.');
+                    layout.groups = layouts[d][qt].groups;
+                }
+
+                return layout;
+            },
+            queryTypes as {[l:string]:LayoutConfigCommon}
+        ) as LayoutsConfig,
+        layouts
+    ) as DomainLayoutsConfig;
 }

--- a/src/js/server/index.ts
+++ b/src/js/server/index.ts
@@ -32,7 +32,7 @@ import * as sessionFileStore from 'session-file-store';
 
 import { ClientStaticConf, ServerConf, DomainLayoutsConfig, DomainAnyTileConf, isTileDBConf, ColorsConf, DataReadabilityMapping, CommonTextStructures } from '../conf';
 import { validateTilesConf } from '../conf/validation';
-import { parseJsonConfig, loadRemoteTileConf } from '../conf/loader';
+import { parseJsonConfig, loadRemoteTileConf, useCommonLayouts } from '../conf/loader';
 import { wdgRouter } from './routes/index';
 import { createToolbarInstance } from './toolbar/factory';
 import { WordDatabases } from './actionServices';
@@ -86,7 +86,7 @@ forkJoin( // load core configs
         ).pipe(
             map<DomainLayoutsConfig, [ServerConf, ClientStaticConf, PackageInfo]>(
                 (layoutsExp) => {
-                    clientConf.layouts = layoutsExp;
+                    clientConf.layouts = useCommonLayouts(layoutsExp);
                     return [serverConf, clientConf, pkgInfo];
                 }
             )


### PR DESCRIPTION
We can now use derived layouts like this:
```
"test": {
      "single": {
        "useLayout": "cs.single",
        "replace": {
          "1": "TimeDistLemmaSynchronic",
          "2": "CollocationsSynchronic",
          "3": "CollocExamplesSynchronic"
        },
        "insertAfter": {
          "2": [{"tile": "WordFormsMain", "width": 1}]
        },
        "groups": []
      }
    }
```

Issue #860