### PR TITLE
Using `wag` as korpusdb _client name

### DIFF
--- a/src/js/server/freqdb/backends/korpusdb.ts
+++ b/src/js/server/freqdb/backends/korpusdb.ts
@@ -144,7 +144,7 @@ export class KorpusFreqDB implements IFreqDB {
                     }],
                     type: ':token:form'
                 },
-                _client: 'wdg'
+                _client: 'wag'
             },
             headers: this.customHeaders
 


### PR DESCRIPTION
Issue #873