### PR TITLE
KorpusDB ngram support

### DIFF
--- a/src/js/conf/index.ts
+++ b/src/js/conf/index.ts
@@ -369,6 +369,7 @@ export interface FreqDbOptions {
     maxSingleTypeNgramArf?:number;
 
     korpusDBCrit?:string;
+    korpusDBNgramCrit?:string;
     korpusDBNorm?:string;
 }
 


### PR DESCRIPTION
Added new setting for ngram frequency criterium, now corpusdb settings might look like this:
```
{
  "path": "https://db.korpus.cz/",
  "corpusSize": 0,
  "dbType": "korpusdb",
  "options": {
    "korpusDBCrit": ":stats:fq:abs:cnc:corpus-syn8",
    "korpusDBNgramCrit": ":stats:fq:abs:synv8:total",
    "korpusDBNorm": "corpus/:cnc:corpus-synv8"
  }
}
```

Issue #878