### PR TITLE
Configure ajv to prevent "Maximum call stack size exceeded"

### DIFF
--- a/launcher-config.json
+++ b/launcher-config.json
@@ -16,7 +16,7 @@
       "typescript-json-schema src/js/conf/index.ts DataReadabilityMapping --ignoreErrors --out conf/dataReadability-schema.json --required --strictNullChecks"
     ],
     "schemata:check-conf": [
-      "ajv -s ./conf/server-schema.json -d ./conf/server.json",
+      "ajv --allow-union-types --all-errors -s ./conf/server-schema.json -d ./conf/server.json",
       "ajv -s ./conf/wdglance-schema.json -d ./conf/wdglance.json",
       "LAYOUTS_PATH=\"$(node -pe 'JSON.parse(fs.readFileSync(\"conf/wdglance.json\", \"utf8\")).layouts')\"",
       "if test -f \"$LAYOUTS_PATH\" 2> /dev/null; then ajv -s ./conf/layouts-schema.json -d $LAYOUTS_PATH; else echo \"layouts config file not found\"; fi",


### PR DESCRIPTION
(the problem was only when validating wdglance.json)