### PR TITLE
Bugfix - incorrectly used throwError

### DIFF
--- a/src/js/api/vendor/kontext/tokenApiWrapper.ts
+++ b/src/js/api/vendor/kontext/tokenApiWrapper.ts
@@ -60,8 +60,9 @@ class TokenApiWrapper<T, U, V extends DataApi<T, U>> {
                             return this.authenticate().pipe(
                                 concatMap(_ => target.call(args))
                             );
+
                         } else {
-                            throwError(() => err);
+                            throw err;
                         }
                     })
                 )


### PR DESCRIPTION
1) it must be returned
2) most of the time "throw err" is enough instead (see docs)