### PR TITLE
Fixes in TimeDist -

### DIFF
--- a/src/js/api/vendor/mquery/timeDistrib.ts
+++ b/src/js/api/vendor/mquery/timeDistrib.ts
@@ -67,7 +67,7 @@ export class MQueryTimeDistribStreamApi implements TimeDistribApi {
             const args = pipe(
                 {
                     q: queryArgs.concIdent,
-                    attr: this.fcrit,
+                    fcrit: this.fcrit,
                     flimit: this.flimit,
                 },
                 Dict.map(
@@ -85,6 +85,7 @@ export class MQueryTimeDistribStreamApi implements TimeDistribApi {
             eventSource.onmessage = (e) => {
                 const message = JSON.parse(e.data) as MqueryStreamData;
                 if (message.error) {
+                    eventSource.close();
                     o.error(new Error(message.error));
 
                 } else {
@@ -95,7 +96,7 @@ export class MQueryTimeDistribStreamApi implements TimeDistribApi {
                             v => ({
                                 datetime: v.word,
                                 freq: v.freq,
-                                norm: v.norm,
+                                norm: message.entries.concSize,
                             }),
                             message.entries.freqs,
                         ),


### PR DESCRIPTION
- invalid arg (attr -> fcrit)
- the EventSource must be closed in case of an error
- make sure the `norm` is always the whole conc. size