### PR TITLE
Fix - with recent MQuery versions, we can use its `norm` values

### DIFF
--- a/src/js/api/vendor/mquery/timeDistrib.ts
+++ b/src/js/api/vendor/mquery/timeDistrib.ts
@@ -96,7 +96,7 @@ export class MQueryTimeDistribStreamApi implements TimeDistribApi {
                             v => ({
                                 datetime: v.word,
                                 freq: v.freq,
-                                norm: message.entries.corpusSize,
+                                norm: v.norm,
                             }),
                             message.entries.freqs,
                         ),


### PR DESCRIPTION
... as they are now correct