### PR TITLE
TimeDistrib - allow custom arguments for API queries

### DIFF
--- a/src/js/api/abstract/timeDistrib.ts
+++ b/src/js/api/abstract/timeDistrib.ts
@@ -29,11 +29,17 @@ export interface TimeDistribArgs {
 
     subcorpName?:string;
 
+    fromYear?:string;
+
+    toYear?:string;
+
     /**
      * This can be either a CQL-ish query or a concordance persistence ID
      */
     concIdent:string;
 }
+
+export type CustomArgs = {[k:string]:string};
 
 /**
  *

--- a/src/js/api/factory/timeDistrib.ts
+++ b/src/js/api/factory/timeDistrib.ts
@@ -20,16 +20,18 @@ import { KontextTimeDistribApi } from '../vendor/kontext/timeDistrib';
 import { CoreApiGroup, supportedCoreApiGroups } from '../coreGroups';
 import { IAsyncKeyValueStore } from '../../types';
 import { NoskeTimeDistribApi } from '../vendor/noske/timeDistrib';
-import { TimeDistribApi } from '../abstract/timeDistrib';
+import { CustomArgs, TimeDistribApi } from '../abstract/timeDistrib';
 import { IApiServices } from '../../appServices';
 import { MQueryTimeDistribStreamApi } from '../vendor/mquery/timeDistrib';
 
-interface ApiConf {
-	fcrit:string;
-	flimit:number;
-}
-
-export function createApiInstance(apiIdent:string, cache:IAsyncKeyValueStore, apiURL:string, apiServices:IApiServices, conf:ApiConf, apiOptions:{}):TimeDistribApi {
+export function createApiInstance(
+	apiIdent:string,
+	cache:IAsyncKeyValueStore,
+	apiURL:string,
+	apiServices:IApiServices,
+	conf:CustomArgs,
+	apiOptions:{}
+):TimeDistribApi {
 
 	switch (apiIdent) {
 		case CoreApiGroup.KONTEXT:
@@ -37,32 +39,28 @@ export function createApiInstance(apiIdent:string, cache:IAsyncKeyValueStore, ap
 				cache,
 				apiURL,
 				apiServices,
-                conf.fcrit,
-                conf.flimit
+                conf
 			);
 		case CoreApiGroup.KONTEXT_API:
 			return new KontextTimeDistribApi(
 				cache,
 				apiURL,
 				apiServices,
-                conf.fcrit,
-                conf.flimit
+                conf
 			);
 		case CoreApiGroup.NOSKE:
 			return new NoskeTimeDistribApi(
 				cache,
 				apiURL,
 				apiServices,
-				conf.fcrit,
-				conf.flimit
+				conf
 			);
 		case CoreApiGroup.MQUERY:
 			return new MQueryTimeDistribStreamApi(
 				cache,
 				apiURL,
 				apiServices,
-                conf.fcrit,
-                conf.flimit
+                conf
 			);
 		default:
 			throw new Error(`TimeDistrib API "${apiIdent}" not found. Supported values are: ${supportedCoreApiGroups().join(', ')}`);

--- a/src/js/api/vendor/kontext/timeDistrib.ts
+++ b/src/js/api/vendor/kontext/timeDistrib.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { TimeDistribApi, TimeDistribArgs, TimeDistribResponse } from '../../abstract/timeDistrib';
+import { CustomArgs, TimeDistribApi, TimeDistribArgs, TimeDistribResponse } from '../../abstract/timeDistrib';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { FreqSort, KontextFreqDistribAPI, BacklinkArgs as FreqBacklinkArgs } from './freqs';
@@ -42,16 +42,13 @@ export class KontextTimeDistribApi implements TimeDistribApi, WebDelegateApi {
 
     private readonly freqApi:KontextFreqDistribAPI;
 
-    private readonly fcrit:string;
-
-    private readonly flimit:number;
+    private readonly customArgs:CustomArgs;
 
     private readonly srcInfoService:CorpusInfoAPI;
 
-    constructor(cache:IAsyncKeyValueStore, apiURL:string, apiServices:IApiServices, fcrit:string, flimit:number) {
+    constructor(cache:IAsyncKeyValueStore, apiURL:string, apiServices:IApiServices, customArgs:CustomArgs) {
         this.freqApi = new KontextFreqDistribAPI(cache, apiURL, apiServices);
-        this.fcrit = fcrit;
-        this.flimit = flimit;
+        this.customArgs = customArgs;
         this.srcInfoService = new CorpusInfoAPI(cache, apiURL, apiServices);
     }
 
@@ -90,9 +87,9 @@ export class KontextTimeDistribApi implements TimeDistribApi, WebDelegateApi {
                 corpname: corpname,
                 usesubcorp: backlink.subcname,
                 q: `~${concId}`,
-                fcrit: [this.fcrit],
+                fcrit: [this.customArgs['fcrit']],
                 freq_type: 'text-types',
-                flimit: this.flimit,
+                flimit: parseInt(this.customArgs['flimit']),
                 freq_sort: FreqSort.REL,
                 fpage: 1,
                 ftt_include_empty: 0
@@ -105,9 +102,9 @@ export class KontextTimeDistribApi implements TimeDistribApi, WebDelegateApi {
             corpname: queryArgs.corpName,
             usesubcorp: queryArgs.subcorpName,
             q: `~${queryArgs.concIdent}`,
-            fcrit: this.fcrit,
+            fcrit: this.customArgs['fcrit'],
             freq_type: 'text-types',
-            flimit: this.flimit,
+            flimit: parseInt(this.customArgs['flimit']),
             freq_sort: FreqSort.REL,
             fpage: 1,
             ftt_include_empty: 0,

--- a/src/js/api/vendor/mquery/timeDistrib.ts
+++ b/src/js/api/vendor/mquery/timeDistrib.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { TimeDistribApi, TimeDistribArgs, TimeDistribResponse } from '../../abstract/timeDistrib';
+import { CustomArgs, TimeDistribApi, TimeDistribArgs, TimeDistribResponse } from '../../abstract/timeDistrib';
 import { Observable } from 'rxjs';
 import { IAsyncKeyValueStore, CorpusDetails } from '../../../types';
 import { Backlink, BacklinkWithArgs } from '../../../page/tile';
@@ -44,14 +44,11 @@ export class MQueryTimeDistribStreamApi implements TimeDistribApi {
 
     private readonly apiURL:string;
 
-    private readonly fcrit:string;
+    private readonly customArgs:CustomArgs;
 
-    private readonly flimit:number;
-
-    constructor(cache:IAsyncKeyValueStore, apiURL:string, apiServices:IApiServices, fcrit:string, flimit:number) {
+    constructor(cache:IAsyncKeyValueStore, apiURL:string, apiServices:IApiServices, customArgs:CustomArgs) {
         this.apiURL = apiURL;
-        this.fcrit = fcrit;
-        this.flimit = flimit;
+        this.customArgs = customArgs;
     }
 
     getSourceDescription(tileId:number, lang:string, corpname:string):Observable<CorpusDetails> {
@@ -66,9 +63,8 @@ export class MQueryTimeDistribStreamApi implements TimeDistribApi {
         return new Observable(o => {
             const args = pipe(
                 {
+                    ...this.customArgs,
                     q: queryArgs.concIdent,
-                    fcrit: this.fcrit,
-                    flimit: this.flimit,
                 },
                 Dict.map(
                     (v, k) => encodeURIComponent(v)

--- a/src/js/api/vendor/noske/timeDistrib.ts
+++ b/src/js/api/vendor/noske/timeDistrib.ts
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-import { TimeDistribApi, TimeDistribArgs, TimeDistribResponse } from '../../abstract/timeDistrib';
+import { CustomArgs, TimeDistribApi, TimeDistribArgs, TimeDistribResponse } from '../../abstract/timeDistrib';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { NoskeFreqDistribAPI } from './freqs';
@@ -43,16 +43,13 @@ export class NoskeTimeDistribApi implements TimeDistribApi {
 
     private readonly freqApi:IFreqDistribAPI<{}>;
 
-    private readonly fcrit:string;
-
-    private readonly flimit:number;
+    private readonly customArgs:CustomArgs;
 
     private readonly srcInfoService:CorpusInfoAPI;
 
-    constructor(cache:IAsyncKeyValueStore, apiURL:string, apiServices:IApiServices, fcrit:string, flimit:number) {
+    constructor(cache:IAsyncKeyValueStore, apiURL:string, apiServices:IApiServices, customArgs:CustomArgs) {
         this.freqApi = new NoskeFreqDistribAPI(cache, apiURL, apiServices);
-        this.fcrit = fcrit;
-        this.flimit = flimit;
+        this.customArgs = customArgs;
         this.srcInfoService = new CorpusInfoAPI(cache, apiURL, apiServices);
     }
 
@@ -87,8 +84,8 @@ export class NoskeTimeDistribApi implements TimeDistribApi {
             corpname: queryArgs.corpName,
             usesubcorp: queryArgs.subcorpName,
             q: processConcId(queryArgs.concIdent),
-            fcrit: this.fcrit,
-            flimit: this.flimit,
+            fcrit: this.customArgs['fcrit'],
+            flimit: this.customArgs['flimit'],
             freq_sort: 'rel',
             fpage: 1,
             format: 'json'

--- a/src/js/tiles/core/multiWordTimeDistrib/common.ts
+++ b/src/js/tiles/core/multiWordTimeDistrib/common.ts
@@ -18,6 +18,7 @@
 import { Action } from 'kombo';
 import { BacklinkWithArgs, CorpSrchTileConf } from '../../../page/tile';
 import { Actions as GlobalActions } from '../../../models/actions';
+import { CustomArgs } from '../../../api/abstract/timeDistrib';
 
 
 export interface TimeDistTileConf extends CorpSrchTileConf {
@@ -27,6 +28,8 @@ export interface TimeDistTileConf extends CorpSrchTileConf {
     apiURL:string|Array<string>;
 
     apiPriority?:Array<number>;
+
+    customApiArgs?:CustomArgs;
 
     /**
      * E.g. doc.pubyear

--- a/src/js/tiles/core/multiWordTimeDistrib/index.ts
+++ b/src/js/tiles/core/multiWordTimeDistrib/index.ts
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { IActionDispatcher, StatelessModel } from 'kombo';
+import { IActionDispatcher } from 'kombo';
 import { List, Maths, pipe } from 'cnc-tskit';
 
 import { FreqSort } from '../../../api/vendor/kontext/freqs';
@@ -97,7 +97,11 @@ export class MultiWordTimeDistTile implements ITileProvider {
                             cache,
                             url,
                             appServices,
-                            conf,
+                            {
+                                ...conf.customApiArgs,
+                                fcrit: conf.fcrit,
+                                flimit: '' + conf.flimit
+                            },
                             apiOptions
                         )
                     ]

--- a/src/js/tiles/core/timeDistrib/common.ts
+++ b/src/js/tiles/core/timeDistrib/common.ts
@@ -18,7 +18,7 @@
 import { Action } from 'kombo';
 import { CorpSrchTileConf, BacklinkWithArgs } from '../../../page/tile';
 import { Actions as GlobalActions } from '../../../models/actions';
-import { FreqRowResponse } from '../../../api/vendor/mquery/common';
+import { CustomArgs } from '../../../api/abstract/timeDistrib';
 
 
 export interface TimeDistTileConf extends CorpSrchTileConf {
@@ -28,6 +28,8 @@ export interface TimeDistTileConf extends CorpSrchTileConf {
     apiURL:string|Array<string>;
 
     apiPriority?:Array<number>;
+
+    customApiArgs?:CustomArgs;
 
     /**
      * E.g. doc.pubyear

--- a/src/js/tiles/core/timeDistrib/index.ts
+++ b/src/js/tiles/core/timeDistrib/index.ts
@@ -99,7 +99,11 @@ export class TimeDistTile implements ITileProvider {
                             cache,
                             url,
                             appServices,
-                            conf,
+                            {
+                                ...conf.customApiArgs,
+                                fcrit: conf.fcrit,
+                                flimit: '' + conf.flimit
+                            },
                             apiOptions,
                         )
                     )
@@ -126,6 +130,7 @@ export class TimeDistTile implements ITileProvider {
                 alphaLevel: Maths.AlphaLevel.LEVEL_1, // TODO conf/explain
                 data: [],
                 dataCmp: [],
+                customApiArgs: conf.customApiArgs ? conf.customApiArgs : {},
                 posQueryGenerator: conf.posQueryGenerator,
                 isTweakMode: false,
                 wordMainLabel: '',

--- a/src/js/tiles/core/timeDistrib/model.ts
+++ b/src/js/tiles/core/timeDistrib/model.ts
@@ -63,6 +63,7 @@ export interface TimeDistribModelState extends MinSingleCritFreqState {
     subcDesc:string;
     alphaLevel:Maths.AlphaLevel;
     posQueryGenerator:[string, string];
+    customApiArgs:{[k:string]:string};
     isTweakMode:boolean;
     data:Array<DataItemWithWCI>;
     dataCmp:Array<DataItemWithWCI>;
@@ -149,8 +150,18 @@ export class TimeDistribModel extends StatelessModel<TimeDistribModelState> {
     private readonly backlink:Backlink;
 
 
-    constructor({dispatcher, initState, tileId, waitForTile, waitForTilesTimeoutSecs, apiFactory, appServices,
-                queryMatches, queryDomain, backlink}:TimeDistribModelArgs) {
+    constructor({
+        dispatcher,
+        initState,
+        tileId,
+        waitForTile,
+        waitForTilesTimeoutSecs,
+        apiFactory,
+        appServices,
+        queryMatches,
+        queryDomain,
+        backlink
+    }:TimeDistribModelArgs) {
         super(dispatcher, initState);
         this.tileId = tileId;
         this.apiFactory = apiFactory;
@@ -370,7 +381,11 @@ export class TimeDistribModel extends StatelessModel<TimeDistribModelState> {
     }
 
 
-    private getFreqs(state:TimeDistribModelState, response:Observable<[TimeDistribResponse, DataFetchArgsOwn|DataFetchArgsForeignConc]>, seDispatch:SEDispatcher) {
+    private getFreqs(
+        state:TimeDistribModelState,
+        response:Observable<[TimeDistribResponse, DataFetchArgsOwn|DataFetchArgsForeignConc]>,
+        seDispatch:SEDispatcher
+    ) {
         response.pipe(
             map(
                 ([resp, args]) => {


### PR DESCRIPTION
In fact, the `fcrit`, `flimit` args should be probably part of that too.