### PR TITLE
Add general support for data streaming.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wag",
-  "version": "0.8.0-beta",
+  "version": "0.9.0-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wag",
-      "version": "0.8.0-beta",
+      "version": "0.9.0-beta",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/d3": "^7.4.0",
@@ -808,311 +808,6 @@
       "resolved": "https://registry.npmjs.org/@napi-rs/nice/-/nice-1.0.1.tgz",
       "integrity": "sha512-zM0mVWSXE0a0h9aKACLwKmD6nHcRiKrPpCfvaKqG1CqDEyjEawId0ocXxVzPMCAm6kkWr2P025msfxXEnt8UGQ==",
       "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Brooooooklyn"
-      },
-      "optionalDependencies": {
-        "@napi-rs/nice-android-arm-eabi": "1.0.1",
-        "@napi-rs/nice-android-arm64": "1.0.1",
-        "@napi-rs/nice-darwin-arm64": "1.0.1",
-        "@napi-rs/nice-darwin-x64": "1.0.1",
-        "@napi-rs/nice-freebsd-x64": "1.0.1",
-        "@napi-rs/nice-linux-arm-gnueabihf": "1.0.1",
-        "@napi-rs/nice-linux-arm64-gnu": "1.0.1",
-        "@napi-rs/nice-linux-arm64-musl": "1.0.1",
-        "@napi-rs/nice-linux-ppc64-gnu": "1.0.1",
-        "@napi-rs/nice-linux-riscv64-gnu": "1.0.1",
-        "@napi-rs/nice-linux-s390x-gnu": "1.0.1",
-        "@napi-rs/nice-linux-x64-gnu": "1.0.1",
-        "@napi-rs/nice-linux-x64-musl": "1.0.1",
-        "@napi-rs/nice-win32-arm64-msvc": "1.0.1",
-        "@napi-rs/nice-win32-ia32-msvc": "1.0.1",
-        "@napi-rs/nice-win32-x64-msvc": "1.0.1"
-      }
-    },
-    "node_modules/@napi-rs/nice-android-arm-eabi": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/nice-android-arm-eabi/-/nice-android-arm-eabi-1.0.1.tgz",
-      "integrity": "sha512-5qpvOu5IGwDo7MEKVqqyAxF90I6aLj4n07OzpARdgDRfz8UbBztTByBp0RC59r3J1Ij8uzYi6jI7r5Lws7nn6w==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/nice-android-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/nice-android-arm64/-/nice-android-arm64-1.0.1.tgz",
-      "integrity": "sha512-GqvXL0P8fZ+mQqG1g0o4AO9hJjQaeYG84FRfZaYjyJtZZZcMjXW5TwkL8Y8UApheJgyE13TQ4YNUssQaTgTyvA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/nice-darwin-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/nice-darwin-arm64/-/nice-darwin-arm64-1.0.1.tgz",
-      "integrity": "sha512-91k3HEqUl2fsrz/sKkuEkscj6EAj3/eZNCLqzD2AA0TtVbkQi8nqxZCZDMkfklULmxLkMxuUdKe7RvG/T6s2AA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/nice-darwin-x64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/nice-darwin-x64/-/nice-darwin-x64-1.0.1.tgz",
-      "integrity": "sha512-jXnMleYSIR/+TAN/p5u+NkCA7yidgswx5ftqzXdD5wgy/hNR92oerTXHc0jrlBisbd7DpzoaGY4cFD7Sm5GlgQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/nice-freebsd-x64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/nice-freebsd-x64/-/nice-freebsd-x64-1.0.1.tgz",
-      "integrity": "sha512-j+iJ/ezONXRQsVIB/FJfwjeQXX7A2tf3gEXs4WUGFrJjpe/z2KB7sOv6zpkm08PofF36C9S7wTNuzHZ/Iiccfw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/nice-linux-arm-gnueabihf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-arm-gnueabihf/-/nice-linux-arm-gnueabihf-1.0.1.tgz",
-      "integrity": "sha512-G8RgJ8FYXYkkSGQwywAUh84m946UTn6l03/vmEXBYNJxQJcD+I3B3k5jmjFG/OPiU8DfvxutOP8bi+F89MCV7Q==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/nice-linux-arm64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-arm64-gnu/-/nice-linux-arm64-gnu-1.0.1.tgz",
-      "integrity": "sha512-IMDak59/W5JSab1oZvmNbrms3mHqcreaCeClUjwlwDr0m3BoR09ZiN8cKFBzuSlXgRdZ4PNqCYNeGQv7YMTjuA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/nice-linux-arm64-musl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-arm64-musl/-/nice-linux-arm64-musl-1.0.1.tgz",
-      "integrity": "sha512-wG8fa2VKuWM4CfjOjjRX9YLIbysSVV1S3Kgm2Fnc67ap/soHBeYZa6AGMeR5BJAylYRjnoVOzV19Cmkco3QEPw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/nice-linux-ppc64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-ppc64-gnu/-/nice-linux-ppc64-gnu-1.0.1.tgz",
-      "integrity": "sha512-lxQ9WrBf0IlNTCA9oS2jg/iAjQyTI6JHzABV664LLrLA/SIdD+I1i3Mjf7TsnoUbgopBcCuDztVLfJ0q9ubf6Q==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/nice-linux-riscv64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-riscv64-gnu/-/nice-linux-riscv64-gnu-1.0.1.tgz",
-      "integrity": "sha512-3xs69dO8WSWBb13KBVex+yvxmUeEsdWexxibqskzoKaWx9AIqkMbWmE2npkazJoopPKX2ULKd8Fm9veEn0g4Ig==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/nice-linux-s390x-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-s390x-gnu/-/nice-linux-s390x-gnu-1.0.1.tgz",
-      "integrity": "sha512-lMFI3i9rlW7hgToyAzTaEybQYGbQHDrpRkg+1gJWEpH0PLAQoZ8jiY0IzakLfNWnVda1eTYYlxxFYzW8Rqczkg==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/nice-linux-x64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-x64-gnu/-/nice-linux-x64-gnu-1.0.1.tgz",
-      "integrity": "sha512-XQAJs7DRN2GpLN6Fb+ZdGFeYZDdGl2Fn3TmFlqEL5JorgWKrQGRUrpGKbgZ25UeZPILuTKJ+OowG2avN8mThBA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/nice-linux-x64-musl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/nice-linux-x64-musl/-/nice-linux-x64-musl-1.0.1.tgz",
-      "integrity": "sha512-/rodHpRSgiI9o1faq9SZOp/o2QkKQg7T+DK0R5AkbnI/YxvAIEHf2cngjYzLMQSQgUhxym+LFr+UGZx4vK4QdQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/nice-win32-arm64-msvc": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/nice-win32-arm64-msvc/-/nice-win32-arm64-msvc-1.0.1.tgz",
-      "integrity": "sha512-rEcz9vZymaCB3OqEXoHnp9YViLct8ugF+6uO5McifTedjq4QMQs3DHz35xBEGhH3gJWEsXMUbzazkz5KNM5YUg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/nice-win32-ia32-msvc": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/nice-win32-ia32-msvc/-/nice-win32-ia32-msvc-1.0.1.tgz",
-      "integrity": "sha512-t7eBAyPUrWL8su3gDxw9xxxqNwZzAqKo0Szv3IjVQd1GpXXVkb6vBBQUuxfIYaXMzZLwlxRQ7uzM2vdUE9ULGw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/nice-win32-x64-msvc": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/nice-win32-x64-msvc/-/nice-win32-x64-msvc-1.0.1.tgz",
-      "integrity": "sha512-JlF+uDcatt3St2ntBG8H02F1mM45i5SF9W+bIKiReVE6wiy3o16oBP/yxt+RZ+N6LbCImJXJ6bXNO2kn9AXicg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@napi-rs/nice": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@napi-rs/nice/-/nice-1.0.1.tgz",
-      "integrity": "sha512-zM0mVWSXE0a0h9aKACLwKmD6nHcRiKrPpCfvaKqG1CqDEyjEawId0ocXxVzPMCAm6kkWr2P025msfxXEnt8UGQ==",
-      "dev": true,
       "optional": true,
       "engines": {
         "node": ">= 10"
@@ -1562,297 +1257,6 @@
       "resolved": "https://registry.npmjs.org/@swc/cli/-/cli-0.6.0.tgz",
       "integrity": "sha512-Q5FsI3Cw0fGMXhmsg7c08i4EmXCrcl+WnAxb6LYOLHw4JFFC3yzmx9LaXZ7QMbA+JZXbigU2TirI7RAfO0Qlnw==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@swc/counter": "^0.1.3",
-        "@xhmikosr/bin-wrapper": "^13.0.5",
-        "commander": "^8.3.0",
-        "fast-glob": "^3.2.5",
-        "minimatch": "^9.0.3",
-        "piscina": "^4.3.1",
-        "semver": "^7.3.8",
-        "slash": "3.0.0",
-        "source-map": "^0.7.3"
-      },
-      "bin": {
-        "spack": "bin/spack.js",
-        "swc": "bin/swc.js",
-        "swcx": "bin/swcx.js"
-      },
-      "engines": {
-        "node": ">= 16.14.0"
-      },
-      "peerDependencies": {
-        "@swc/core": "^1.2.66",
-        "chokidar": "^4.0.1"
-      },
-      "peerDependenciesMeta": {
-        "chokidar": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@swc/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-67+lBHZ1lAJQKoOhBHl9DE2iugPYAulRVArZjoF+DnIY3G9wLXCXxw5It0IaCnzvJVvUPxGmr0rHViXKBDP5Vg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/counter": "^0.1.3",
-        "@swc/types": "^0.1.18"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/swc"
-      },
-      "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.11.1",
-        "@swc/core-darwin-x64": "1.11.1",
-        "@swc/core-linux-arm-gnueabihf": "1.11.1",
-        "@swc/core-linux-arm64-gnu": "1.11.1",
-        "@swc/core-linux-arm64-musl": "1.11.1",
-        "@swc/core-linux-x64-gnu": "1.11.1",
-        "@swc/core-linux-x64-musl": "1.11.1",
-        "@swc/core-win32-arm64-msvc": "1.11.1",
-        "@swc/core-win32-ia32-msvc": "1.11.1",
-        "@swc/core-win32-x64-msvc": "1.11.1"
-      },
-      "peerDependencies": {
-        "@swc/helpers": "*"
-      },
-      "peerDependenciesMeta": {
-        "@swc/helpers": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.11.1.tgz",
-      "integrity": "sha512-bJbqZ51JghEZ8WaFetofkfkS3MWsS/V3vDvY+0r+SlLeocZwf8q8/GqcafnElHcU+zLV6yTi13fJwUce6ULiUQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-darwin-x64": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.11.1.tgz",
-      "integrity": "sha512-9GGEoN0uxkLg3KocOVzMfe9c9/DxESXclsL/U2xVLa3pTFB5YnXhiCP5YBT/3Q7nSGLD+R2ALqkNlDoueUjvPw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.11.1.tgz",
-      "integrity": "sha512-Lt7l/l0nfSTUzsWcVY3dtOPl5RtgCJ+Ya8IG4Aa3l6c7kLc6Sx4JpylpEIY9yhGidDy/uQ8KUg5kqUPtUrXrvQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.11.1.tgz",
-      "integrity": "sha512-oe826cfuGukctTSpDjk7RJRDEJihQMAzvO5tdWK0wcy+zvMPFyH5Fg6cW0X4ST3M7fcV91/1T/iuiiD2SVamYw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.11.1.tgz",
-      "integrity": "sha512-ABb4pnYeQp/JBJS5Qd2apTwOzpzrTebQFUiFjk0WgTKIr9T6SL3tLXMjgvbSXIath+1HnbCKFUwDXNQhgGFFTg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.11.1.tgz",
-      "integrity": "sha512-E09TcHv40bV0mOHTKquZw0IOcQ+lzzpQjyOhCa7+GBpbS3eg5/35Gu7DfToN2bomz74LPKW/l7jZRG+ZNOYNHQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.11.1.tgz",
-      "integrity": "sha512-cuW4r7GbvQt9uv+rGdYLHUjDvGjHmr1nYE7iFVk6r4i+byZuXBK6M7P1p+/dTzacshOc05I9n/eUV+Hfjp9a3A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.11.1.tgz",
-      "integrity": "sha512-H8Q78GwaKnCL4isHx8JRTRi6vUU6iMLbpegS2jzWWC1On7EePhkLx2eR8nEsaRIQB6rc3WqdIj74OgOpNoPi7g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.11.1.tgz",
-      "integrity": "sha512-Rx7cZ0OvqMb16fgmUSlPWQbH1+X355IDJhVQpUlpL+ezD/kkWmJix+4u2GVE/LHrfbdyZ4sjjIzSsCQxJV05Mw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.11.1.tgz",
-      "integrity": "sha512-6bEEC/XU1lwYzUXY7BXj3nhe7iBF9+i9dVo+hbiVxXZMrD0LUd+7urOBM3NtVnDsUaR6Ge/g7aR+OfpgYscKOg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0 AND MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@swc/counter": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
-      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
-    "node_modules/@swc/plugin-styled-components": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@swc/plugin-styled-components/-/plugin-styled-components-7.0.0.tgz",
-      "integrity": "sha512-22ki8qobTqDVVBj48uG0GCdprXdqvLPP8q4brKwSIayw86qfZeSGmlYtif6bQ5ftqRwV9jwJVY45DvXCk0FEgg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/counter": "^0.1.3"
-      }
-    },
-    "node_modules/@swc/types": {
-      "version": "0.1.18",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.18.tgz",
-      "integrity": "sha512-NZghLaQvF3eFdj2DUjGkpwaunbZYaRcxciHINnwA4n3FrLAI8hKFOBqs2wkcOiLQfWkIdfuG6gBkNFrkPNji5g==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@swc/counter": "^0.1.3"
-      }
-    },
-    "node_modules/@szmarczak/http-timer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
-      "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "defer-to-connect": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=14.16"
-      }
-    },
-    "node_modules/@tokenizer/token": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@swc/cli": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@swc/cli/-/cli-0.6.0.tgz",
-      "integrity": "sha512-Q5FsI3Cw0fGMXhmsg7c08i4EmXCrcl+WnAxb6LYOLHw4JFFC3yzmx9LaXZ7QMbA+JZXbigU2TirI7RAfO0Qlnw==",
-      "dev": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@xhmikosr/bin-wrapper": "^13.0.5",
@@ -1937,14 +1341,14 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.10.18",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.10.18.tgz",
-      "integrity": "sha512-IUWKD6uQYGRy8w2X9EZrtYg1O3SCijlHbCXzMaHQYc1X7yjijQh4H3IVL9ssZZyVp2ZDfQZu4bD5DWxxvpyjvg==",
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.11.4.tgz",
+      "integrity": "sha512-EHl6eNod/914xDRK4nu7gr78riK2cfi4DkAMvJt6COdaNGOnbR5eKrLe3SnRizyzzrPcxUMhflDL5hrcXS8rAQ==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
-        "@swc/types": "^0.1.17"
+        "@swc/types": "^0.1.19"
       },
       "engines": {
         "node": ">=10"
@@ -1954,16 +1358,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.10.18",
-        "@swc/core-darwin-x64": "1.10.18",
-        "@swc/core-linux-arm-gnueabihf": "1.10.18",
-        "@swc/core-linux-arm64-gnu": "1.10.18",
-        "@swc/core-linux-arm64-musl": "1.10.18",
-        "@swc/core-linux-x64-gnu": "1.10.18",
-        "@swc/core-linux-x64-musl": "1.10.18",
-        "@swc/core-win32-arm64-msvc": "1.10.18",
-        "@swc/core-win32-ia32-msvc": "1.10.18",
-        "@swc/core-win32-x64-msvc": "1.10.18"
+        "@swc/core-darwin-arm64": "1.11.4",
+        "@swc/core-darwin-x64": "1.11.4",
+        "@swc/core-linux-arm-gnueabihf": "1.11.4",
+        "@swc/core-linux-arm64-gnu": "1.11.4",
+        "@swc/core-linux-arm64-musl": "1.11.4",
+        "@swc/core-linux-x64-gnu": "1.11.4",
+        "@swc/core-linux-x64-musl": "1.11.4",
+        "@swc/core-win32-arm64-msvc": "1.11.4",
+        "@swc/core-win32-ia32-msvc": "1.11.4",
+        "@swc/core-win32-x64-msvc": "1.11.4"
       },
       "peerDependencies": {
         "@swc/helpers": "*"
@@ -1975,9 +1379,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.10.18",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.10.18.tgz",
-      "integrity": "sha512-FdGqzAIKVQJu8ROlnHElP59XAUsUzCFSNsou+tY/9ba+lhu8R9v0OI5wXiPErrKGZpQFMmx/BPqqhx3X4SuGNg==",
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.11.4.tgz",
+      "integrity": "sha512-Oi4lt4wqjpp80pcCh+vzvpsESJ8XXozYCE5EM/dDpr+9m2oRpkseds7Gq4ulzgdbUDPo1jJ1PonjjrKpfKY+sQ==",
       "cpu": [
         "arm64"
       ],
@@ -1991,9 +1395,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.10.18",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.10.18.tgz",
-      "integrity": "sha512-RZ73gZRituL/ZVLgrW6BYnQ5g8tuStG4cLUiPGJsUZpUm0ullSH6lHFvZTCBNFTfpQChG6eEhi2IdG6DwFp1lw==",
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.11.4.tgz",
+      "integrity": "sha512-Tb7ez94DXxhX5iJ5slnAlT2gwJinQk3pMnQ46Npi6adKr3ZXM5Bdk0jpRUp8XjEcgNXkQRV1DtrySgCz6YlEnQ==",
       "cpu": [
         "x64"
       ],
@@ -2007,9 +1411,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.10.18",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.10.18.tgz",
-      "integrity": "sha512-8iJqI3EkxJuuq21UHoen1VS+QlS23RvynRuk95K+Q2HBjygetztCGGEc+Xelx9a0uPkDaaAtFvds4JMDqb9SAA==",
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.11.4.tgz",
+      "integrity": "sha512-p1uV+6Mi+0M+1kL7qL206ZaohomYMW7yroXSLDTJXbIylx7wG2xrUQL6AFtz2DwqDoX/E8jMNBjp+GcEy8r8Ig==",
       "cpu": [
         "arm"
       ],
@@ -2023,9 +1427,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.10.18",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.10.18.tgz",
-      "integrity": "sha512-8f1kSktWzMB6PG+r8lOlCfXz5E8Qhsmfwonn77T/OfjvGwQaWrcoASh2cdjpk3dydbf8jsKGPQE1lSc7GyjXRQ==",
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.11.4.tgz",
+      "integrity": "sha512-4ijX4bWf9oc7kWkT6xUhugVGzEJ7U9c7CHNmt/xhI/yWsQdfM11+HECqWh7ay3m+aaEoVdvTeU5gykeF5jSxDA==",
       "cpu": [
         "arm64"
       ],
@@ -2039,9 +1443,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.10.18",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.10.18.tgz",
-      "integrity": "sha512-4rv+E4VLdgQw6zjbTAauCAEExxChvxMpBUMCiZweTNPKbJJ2dY6BX2WGJ1ea8+RcgqR/Xysj3AFbOz1LBz6dGA==",
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.11.4.tgz",
+      "integrity": "sha512-XI+gOgcuSanejbAC5QXKTjNA3GUJi7bzHmeJbNhKpX9d349RdVwan0k9okHmhMBY7BywAg3LK0ovF9PmOLgMHg==",
       "cpu": [
         "arm64"
       ],
@@ -2055,9 +1459,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.10.18",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.10.18.tgz",
-      "integrity": "sha512-vTNmyRBVP+sZca+vtwygYPGTNudTU6Gl6XhaZZ7cEUTBr8xvSTgEmYXoK/2uzyXpaTUI4Bmtp1x81cGN0mMoLQ==",
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.11.4.tgz",
+      "integrity": "sha512-wyD6noaCPFayKOvl9mTxuiQoEULAagGuO0od2VkW7h4HvlgpOAZNekZYX73WEP/b+WuePNHurZ9KGpom43IzmA==",
       "cpu": [
         "x64"
       ],
@@ -2071,9 +1475,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.10.18",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.10.18.tgz",
-      "integrity": "sha512-1TZPReKhFCeX776XaT6wegknfg+g3zODve+r4oslFHI+g7cInfWlxoGNDS3niPKyuafgCdOjme2g3OF+zzxfsQ==",
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.11.4.tgz",
+      "integrity": "sha512-e2vG9gUF1BRX0BWqSEHop6u14l5BtV3VS2Pmr+oquc0Ycs/zj81xhYc3ML4ByK5OxDkAaKBWryAOKTLaJA/DVg==",
       "cpu": [
         "x64"
       ],
@@ -2087,9 +1491,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.10.18",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.10.18.tgz",
-      "integrity": "sha512-o/2CsaWSN3bkzVQ6DA+BiFKSVEYvhWGA1h+wnL2zWmIDs2Knag54sOEXZkCaf8YQyZesGeXJtPEy9hh/vjJgkA==",
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.11.4.tgz",
+      "integrity": "sha512-rm51iljNqjCA/41gxYameuyjX1ENaTlvdxmaoPPYeUDt6hfypG93IxMJJCewaeHN9XfNxqZU7d4cupNqk+8nng==",
       "cpu": [
         "arm64"
       ],
@@ -2103,9 +1507,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.10.18",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.10.18.tgz",
-      "integrity": "sha512-eTPASeJtk4mJDfWiYEiOC6OYUi/N7meHbNHcU8e+aKABonhXrIo/FmnTE8vsUtC6+jakT1TQBdiQ8fzJ1kJVwA==",
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.11.4.tgz",
+      "integrity": "sha512-PHy3N6zlyU8te7Umi0ggXNbcx2VUkwpE59PW9FQQy9MBZM1Qn+OEGnO/4KLWjGFABw+9CwIeaRYgq6uCi1ry6A==",
       "cpu": [
         "ia32"
       ],
@@ -2119,9 +1523,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.10.18",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.10.18.tgz",
-      "integrity": "sha512-1Dud8CDBnc34wkBOboFBQud9YlV1bcIQtKSg7zC8LtwR3h+XAaCayZPkpGmmAlCv1DLQPvkF+s0JcaVC9mfffQ==",
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.11.4.tgz",
+      "integrity": "sha512-0TiriDGl7Dr4ObfMBk07PS4Ql5hgQH0QnU3E8I+fbs45hqfwC5OrN47HOsXx4ZbEw8XYxp2NM8SGnVoTIm4J8w==",
       "cpu": [
         "x64"
       ],
@@ -2140,10 +1544,20 @@
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
       "dev": true
     },
+    "node_modules/@swc/plugin-styled-components": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@swc/plugin-styled-components/-/plugin-styled-components-7.0.0.tgz",
+      "integrity": "sha512-22ki8qobTqDVVBj48uG0GCdprXdqvLPP8q4brKwSIayw86qfZeSGmlYtif6bQ5ftqRwV9jwJVY45DvXCk0FEgg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3"
+      }
+    },
     "node_modules/@swc/types": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.17.tgz",
-      "integrity": "sha512-V5gRru+aD8YVyCOMAjMpWR1Ui577DD5KSJsHP8RAxopAH22jFz6GZd/qxqjO6MJHQhcsjvjOFXyDhyLQUnMveQ==",
+      "version": "0.1.19",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.19.tgz",
+      "integrity": "sha512-WkAZaAfj44kh/UFdAQcrMP1I0nwRqpt27u+08LMBYMqmQfwwMofYoMh/48NGkMMRfC4ynpfwRbJuu8ErfNloeA==",
       "dev": true,
       "dependencies": {
         "@swc/counter": "^0.1.3"
@@ -3479,27 +2893,6 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ],
-      "license": "MIT"
-    },
-    "node_modules/arch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/arch/-/arch-3.0.0.tgz",
-      "integrity": "sha512-AmIAC+Wtm2AU8lGfTtHsw0Y9Qtftx2YXEEtiBP10xFUtMOA+sHHx6OAddyL52mUKh1vsXQ6/w1mVDptZCyUt4Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
       ]
     },
     "node_modules/are-we-there-yet": {
@@ -3630,14 +3023,6 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "devOptional": true,
       "license": "MIT"
-    },
-    "node_modules/bare-events": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
-      "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true
     },
     "node_modules/bare-events": {
       "version": "2.5.4",
@@ -3948,22 +3333,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/bundle-name": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
-      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "run-applescript": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -4200,11 +3569,12 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
       "dev": true,
-      "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "readdirp": "^4.0.1"
       },
@@ -4213,9 +3583,6 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
       }
     },
     "node_modules/chownr": {
@@ -4373,16 +3740,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/compressible": {
@@ -5016,7 +4373,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -5031,34 +4387,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/decompress-response": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "dev": true,
-      "dependencies": {
-        "mimic-response": "^3.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/decompress-response/node_modules/mimic-response": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -5790,33 +5118,6 @@
       "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
       "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.28.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/ext-name": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ext-name/-/ext-name-5.0.0.tgz",
-      "integrity": "sha512-yblEwXAbGv1VQDmow7s38W77hzAgJAO50ztBLMcUyUBfxv1HC+LGwtiEN+Co6LtlqT/5uwVOxsD4TNIilWhwdQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ext-list": "^2.0.0",
-        "sort-keys-length": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/ext-list": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/ext-list/-/ext-list-2.2.2.tgz",
-      "integrity": "sha512-u+SQgsubraE6zItfVA0tBuCBhfU9ogSRnsvygI7wht9TS510oLkBRXBsqopeUG/GBOIQyKZO9wjTqIu/sf5zFA==",
-      "dev": true,
       "dependencies": {
         "mime-db": "^1.28.0"
       },
@@ -5940,22 +5241,6 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/fastest-levenshtein": {
       "version": "1.0.16",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
@@ -6015,7 +5300,6 @@
       "resolved": "https://registry.npmjs.org/file-type/-/file-type-19.6.0.tgz",
       "integrity": "sha512-VZR5I7k5wkD0HgFnMsq5hOsSc710MJMu5Nc5QYsbe38NN5iPV/XTObYLc/cpttRTf6lX538+5uO1ZQRhYibiZQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "get-stream": "^9.0.1",
         "strtok3": "^9.0.1",
@@ -6034,7 +5318,6 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
       "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@sec-ant/readable-stream": "^0.4.1",
         "is-stream": "^4.0.1"
@@ -6051,7 +5334,6 @@
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
       "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -6064,81 +5346,6 @@
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT"
-    },
-    "node_modules/filename-reserved-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-3.0.0.tgz",
-      "integrity": "sha512-hn4cQfU6GOT/7cFHXBqeBg2TbrMBgdD0kcjLhvSQYYwm3s4B6cjvBfb7nBALJLAXqmU5xajSa7X2NnUud/VCdw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/filenamify": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-6.0.0.tgz",
-      "integrity": "sha512-vqIlNogKeyD3yzrm0yhRMQg8hOVwYcYRfjEoODd49iCprMn4HL85gK3HcykQE53EPIpX3HcAbGA5ELQv216dAQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "filename-reserved-regex": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/file-type": {
-      "version": "19.6.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-19.6.0.tgz",
-      "integrity": "sha512-VZR5I7k5wkD0HgFnMsq5hOsSc710MJMu5Nc5QYsbe38NN5iPV/XTObYLc/cpttRTf6lX538+5uO1ZQRhYibiZQ==",
-      "dev": true,
-      "dependencies": {
-        "get-stream": "^9.0.1",
-        "strtok3": "^9.0.1",
-        "token-types": "^6.0.0",
-        "uint8array-extras": "^1.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
-      }
-    },
-    "node_modules/file-type/node_modules/get-stream": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-9.0.1.tgz",
-      "integrity": "sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==",
-      "dev": true,
-      "dependencies": {
-        "@sec-ant/readable-stream": "^0.4.1",
-        "is-stream": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/file-type/node_modules/is-stream": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-4.0.1.tgz",
-      "integrity": "sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/filename-reserved-regex": {
       "version": "3.0.0",
@@ -6372,21 +5579,6 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "devOptional": true,
       "license": "ISC"
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -7141,16 +6333,6 @@
       "resolved": "https://registry.npmjs.org/inspect-with-kind/-/inspect-with-kind-1.0.5.tgz",
       "integrity": "sha512-MAQUJuIo7Xqk8EVNP+6d3CKq9c80hi4tjIbIAT6lmGW9W6WzlHiu9PS8uSuUYU+Do+j1baiFp3H25XEVxDIG2g==",
       "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "kind-of": "^6.0.2"
-      }
-    },
-    "node_modules/inspect-with-kind": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/inspect-with-kind/-/inspect-with-kind-1.0.5.tgz",
-      "integrity": "sha512-MAQUJuIo7Xqk8EVNP+6d3CKq9c80hi4tjIbIAT6lmGW9W6WzlHiu9PS8uSuUYU+Do+j1baiFp3H25XEVxDIG2g==",
-      "dev": true,
       "dependencies": {
         "kind-of": "^6.0.2"
       }
@@ -7529,13 +6711,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/json-buffer": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true
     },
     "node_modules/json-parse-even-better-errors": {
@@ -7589,16 +6764,6 @@
       "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/keyv": {
-      "version": "4.5.4",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "json-buffer": "3.0.1"
-      }
     },
     "node_modules/keyv": {
       "version": "4.5.4",
@@ -7760,19 +6925,6 @@
       "license": "MIT",
       "dependencies": {
         "get-func-name": "^2.0.1"
-      }
-    },
-    "node_modules/lowercase-keys": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
-      "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lowercase-keys": {
@@ -8017,22 +7169,6 @@
       "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
       "license": "ISC"
     },
-    "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -8198,6 +7334,30 @@
       "dev": true,
       "license": "Python-2.0"
     },
+    "node_modules/mocha/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/mocha/node_modules/debug": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
@@ -8295,6 +7455,18 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/mocha/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
     },
     "node_modules/mock-xmlhttprequest": {
       "version": "7.0.4",
@@ -8890,40 +8062,6 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
-    "node_modules/path-scurry": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
-      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^10.2.0",
-        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/path-scurry/node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/path-to-regexp": {
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
@@ -9083,16 +8221,6 @@
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
       "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
       "license": "MIT"
-    },
-    "node_modules/piscina": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/piscina/-/piscina-4.8.0.tgz",
-      "integrity": "sha512-EZJb+ZxDrQf3dihsUL7p42pjNyrNIFJCrRHPMgxu/svsj+P3xS3fuEWp7k2+rfsavfl1N0G29b1HGs7J0m8rZA==",
-      "dev": true,
-      "license": "MIT",
-      "optionalDependencies": {
-        "@napi-rs/nice": "^1.0.1"
-      }
     },
     "node_modules/piscina": {
       "version": "4.8.0",
@@ -9448,19 +8576,6 @@
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -9625,6 +8740,8 @@
       "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
       "dev": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -9858,19 +8975,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/run-applescript": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
-      "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -10079,30 +9183,6 @@
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-2.0.0.tgz",
       "integrity": "sha512-SMguiTnYrhpLdk3PwfzHeotrcwi8bNV4iemL9tx9poR/yeaMYwB9VzR1w7b57DuWpuqR8n6oZboi0hj3AxZxQg==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "commander": "^6.0.0"
-      },
-      "bin": {
-        "seek-bunzip": "bin/seek-bunzip",
-        "seek-table": "bin/seek-bzip-table"
-      }
-    },
-    "node_modules/seek-bzip/node_modules/commander": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-6.2.1.tgz",
-      "integrity": "sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/seek-bzip": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-2.0.0.tgz",
-      "integrity": "sha512-SMguiTnYrhpLdk3PwfzHeotrcwi8bNV4iemL9tx9poR/yeaMYwB9VzR1w7b57DuWpuqR8n6oZboi0hj3AxZxQg==",
-      "dev": true,
       "dependencies": {
         "commander": "^6.0.0"
       },
@@ -10151,35 +9231,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/semver-regex": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/semver-regex/-/semver-regex-4.0.5.tgz",
-      "integrity": "sha512-hunMQrEy1T6Jr2uEVjrAIqjwWcQTgOAcIM52C8MY1EZSD3DDNft04XzvYKPqjED65bNVVko0YI38nYeEHCX3yw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semver-truncate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/semver-truncate/-/semver-truncate-3.0.0.tgz",
-      "integrity": "sha512-LJWA9kSvMolR51oDE6PN3kALBNaUdkxzAGcexw8gjMA8xr5zUqK0JiR3CgARSqanYF3Z1YHvsErb1KDgh+v7Rg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/semver-regex": {
@@ -10607,16 +9658,6 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/slash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -10732,16 +9773,6 @@
       },
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/source-map-js": {
@@ -10977,22 +10008,6 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "devOptional": true,
-      "license": "MIT",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width-cjs": {
-      "name": "string-width",
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -11370,29 +10385,6 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/text-decoder": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
-      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "b4a": "^1.6.4"
-      }
-    },
-    "node_modules/thingies": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/thingies/-/thingies-1.21.0.tgz",
-      "integrity": "sha512-hsqsJsFMsV+aD4s3CWKk85ep/3I9XzYV/IXaSouJMYIoDlgyi11cBhsqYe9/geRfB0YIikBQg6raRaM+nIMP9g==",
-      "dev": true,
-      "license": "Unlicense",
-      "engines": {
-        "node": ">=10.18"
-      },
-      "peerDependencies": {
-        "tslib": "^2"
-      }
     },
     "node_modules/text-decoder": {
       "version": "1.2.3",
@@ -12130,6 +11122,30 @@
         }
       }
     },
+    "node_modules/webpack-dev-server/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/webpack-dev-server/node_modules/ipaddr.js": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
@@ -12138,6 +11154,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/webpack-dev-server/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
       }
     },
     "node_modules/webpack-dev-server/node_modules/schema-utils": {

--- a/src/js/api/abstract/freqs.ts
+++ b/src/js/api/abstract/freqs.ts
@@ -44,7 +44,7 @@ export interface IFreqDistribAPI<T> extends ResourceApi<T, APIResponse> {
 
     stateToArgs(state:MinSingleCritFreqState, concId:string, subcname?:string):T;
 
-    call(args:T):Observable<APIResponse>;
+    call(tileId:number, args:T):Observable<APIResponse>;
 
     getSourceDescription(tileId:number, lang:string, corpname:string):Observable<SourceDetails>;
 
@@ -68,7 +68,7 @@ export interface APIBlockResponse {
 export interface IMultiBlockFreqDistribAPI<T> extends ResourceApi<T, APIBlockResponse> {
     stateToArgs(state:MinMultiCritFreqState, concId:string, critIdx?:number, subcname?:string):T;
 
-    call(args:T):Observable<APIBlockResponse>;
+    call(tileId:number, args:T):Observable<APIBlockResponse>;
 
     getSourceDescription(tileId:number, lang:string, corpname:string):Observable<SourceDetails>;
 

--- a/src/js/api/coreGroups.ts
+++ b/src/js/api/coreGroups.ts
@@ -40,6 +40,7 @@ export enum CoreApiGroup {
 	KONTEXT_LIVEATTRS = 'kontextLiveattrs',  // kontext with liveattrs support
 	KONTEXT_API = 'kontextApi',
 	KONTEXT_API_LIVEATTRS = 'kontextApiLiveattrs',  // kontext api with liveattrs support
+	KONTEXT_API_EXPERIMENTAL = 'kontextApiExperimental',
 
 	/**
 	 * Leipzig Corpora Collection

--- a/src/js/api/factory/concordance.ts
+++ b/src/js/api/factory/concordance.ts
@@ -24,6 +24,7 @@ import { FCS1SearchRetrieveAPI } from '../vendor/clarin/fcs1/searchRetrieve.js';
 import { FCS1ExplainAPI } from '../vendor/clarin/fcs1/explain.js';
 import { CoreApiGroup, supportedCoreApiGroups } from '../coreGroups.js';
 import { IApiServices, IAppServices } from '../../appServices.js';
+import { ConcApiSimplified } from '../vendor/kontext/concordance/experimental/index.js';
 
 
 export function createKontextConcApiInstance(apiIdent:string, apiURL:string, apiServices:IApiServices, apiOptions:{}):ConcApi015 {
@@ -38,7 +39,13 @@ export function createKontextConcApiInstance(apiIdent:string, apiURL:string, api
 	}
 }
 
-export function createApiInstance(apiIdent:string, apiURL:string, apiServices:IApiServices, apiOptions:{}):IConcordanceApi<{}> {
+export function createApiInstance(
+	apiIdent:string,
+	apiURL:string,
+	useDataStream:boolean,
+	apiServices:IApiServices,
+	apiOptions:{}
+):IConcordanceApi<{}> {
 
  	switch (apiIdent) {
 		case CoreApiGroup.FCS_V1:
@@ -46,6 +53,8 @@ export function createApiInstance(apiIdent:string, apiURL:string, apiServices:IA
  		case CoreApiGroup.KONTEXT:
 		case CoreApiGroup.KONTEXT_API:
 			return createKontextConcApiInstance(apiIdent, apiURL, apiServices, apiOptions);
+		case CoreApiGroup.KONTEXT_API_EXPERIMENTAL:
+			return new ConcApiSimplified(apiURL, useDataStream, apiServices);
 		case CoreApiGroup.NOSKE:
 			return new NoskeConcApi(apiURL, apiServices);
 		case CoreApiGroup.LCC:

--- a/src/js/api/lemma.ts
+++ b/src/js/api/lemma.ts
@@ -47,7 +47,7 @@ export class LemmaDbApi implements DataApi<LemmaDbRequestArgs, LemmaDbResponse> 
         this.url = url;
     }
 
-    call(args:LemmaDbRequestArgs):Observable<LemmaDbResponse> {
+    call(tileId:number, args:LemmaDbRequestArgs):Observable<LemmaDbResponse> {
         return ajax$<LemmaDbResponse>(
             HTTP.Method.GET,
             this.url,

--- a/src/js/api/util.ts
+++ b/src/js/api/util.ts
@@ -29,8 +29,8 @@ import { DataApi } from '../types.js';
  * @param args API call arguments
  * @param passThrough
  */
-export const callWithExtraVal = <T, U, V>(api:DataApi<T, U>, args:T, passThrough:V):Observable<[U, V]> => {
-    return api.call(args).pipe(
+export const callWithExtraVal = <T, U, V>(api:DataApi<T, U>, tileId:number, args:T, passThrough:V):Observable<[U, V]> => {
+    return api.call(tileId, args).pipe(
         map(v => [v, passThrough] as [U, V])
     );
 }

--- a/src/js/api/vendor/clarin/fcs1/explain.ts
+++ b/src/js/api/vendor/clarin/fcs1/explain.ts
@@ -101,7 +101,7 @@ export class FCS1ExplainAPI implements DataApi<FCS1ExplainArgs, FCS1ExplainRespo
         this.parser = new XMLParser();
     }
 
-	call(args:FCS1ExplainArgs):Observable<FCS1ExplainResponse> {
+	call(tileId:number, args:FCS1ExplainArgs):Observable<FCS1ExplainResponse> {
         return ajax$(
             HTTP.Method.GET,
             this.url,

--- a/src/js/api/vendor/clarin/fcs1/searchRetrieve.ts
+++ b/src/js/api/vendor/clarin/fcs1/searchRetrieve.ts
@@ -176,14 +176,14 @@ export class FCS1SearchRetrieveAPI implements IConcordanceApi<FCS1Args> {
     }
 
     getSourceDescription(tileId:number, lang:string, corpname:string):Observable<FCS1ExplainResponse> {
-        return this.srcInfoApi.call({
+        return this.srcInfoApi.call(tileId, {
             tileId: tileId,
             uiLang: lang,
             'x-fcs-endpoint-description': 'true' // TODO
         });
     }
 
-	call(args:FCS1Args):Observable<ConcResponse> {
+	call(tileId:number, args:FCS1Args):Observable<ConcResponse> {
 		return ajax$(
             HTTP.Method.GET,
             this.url,

--- a/src/js/api/vendor/datamuse/wordSim.ts
+++ b/src/js/api/vendor/datamuse/wordSim.ts
@@ -85,7 +85,7 @@ export class DatamuseMLApi implements IWordSimApi<DatamuseMLApiArgs|DatamuseSLAp
         });
     }
 
-    call(queryArgs:DatamuseApiArgs):Observable<WordSimApiResponse> {
+    call(tileId:number, queryArgs:DatamuseApiArgs):Observable<WordSimApiResponse> {
         return ajax$<DatamuseMLApiResponse>(
             'GET',
             this.apiURL,

--- a/src/js/api/vendor/elasticsearch/matchingDocs.ts
+++ b/src/js/api/vendor/elasticsearch/matchingDocs.ts
@@ -83,7 +83,7 @@ export class ElasticsearchMatchingDocsAPI implements MatchingDocsAPI<Elasticsear
         return null;
     }
 
-    call(args:ElasticsearchQueryArgs):Observable<APIResponse> {
+    call(tileId:number, args:ElasticsearchQueryArgs):Observable<APIResponse> {
         return ajax$<HTTPResponse>(
             'GET',
             this.apiURL,

--- a/src/js/api/vendor/kontext/collocations.ts
+++ b/src/js/api/vendor/kontext/collocations.ts
@@ -109,14 +109,13 @@ export class KontextCollAPI implements CollocationApi<CollApiArgs>, WebDelegateA
     }
 
     getSourceDescription(tileId:number, lang:string, corpname:string):Observable<SourceDetails> {
-        return this.srcInfoService.call({
-            tileId: tileId,
+        return this.srcInfoService.call(tileId, {
             corpname: corpname,
             format: 'json'
         });
     }
 
-    call(queryArgs:CollApiArgs):Observable<CollApiResponse> {
+    call(tileId:number, queryArgs:CollApiArgs):Observable<CollApiResponse> {
         const headers = this.apiServices.getApiHeaders(this.apiURL);
         headers['X-Is-Web-App'] = '1';
         return ajax$<HttpApiResponse>(

--- a/src/js/api/vendor/kontext/concReduce.ts
+++ b/src/js/api/vendor/kontext/concReduce.ts
@@ -52,7 +52,7 @@ export class ConcReduceApi implements DataApi<RequestArgs, ApiResponse> {
         this.apiServices = apiServices;
     }
 
-    call(args:RequestArgs):Observable<ApiResponse> {
+    call(tileId:number, args:RequestArgs):Observable<ApiResponse> {
         const headers = this.apiServices.getApiHeaders(this.apiURL);
         headers['X-Is-Web-App'] = '1';
         return ajax$<ConcViewResponse>(

--- a/src/js/api/vendor/kontext/concordance/experimental/index.ts
+++ b/src/js/api/vendor/kontext/concordance/experimental/index.ts
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2025 Tomas Machalek <tomas.machalek@gmail.com>
+ * Copyright 2025 Institute of the Czech National Corpus,
+ *                Faculty of Arts, Charles University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { map, Observable, tap } from 'rxjs';
+import { List, HTTP, URL, tuple } from 'cnc-tskit';
+
+import { ajax$ } from '../../../../../page/ajax.js';
+import { CorpusDetails, WebDelegateApi } from '../../../../../types.js';
+import { QueryMatch } from '../../../../../query/index.js';
+import { ConcResponse, ViewMode, IConcordanceApi } from '../../../../abstract/concordance.js';
+import { ConcordanceMinState } from '../../../../../models/tiles/concordance/index.js';
+import { CorpusInfoAPI } from '../../corpusInfo.js';
+import { IApiServices } from '../../../../../appServices.js';
+import { ConcViewResponse, convertLines, mkLemmaMatchQuery, mkWordMatchQuery, PersistentConcArgs} from '../v015/common.js';
+import { ConcQueryArgs } from '../../types.js';
+import { Backlink } from '../../../../../page/tile.js';
+
+
+
+/**
+ * ConcApiSimplified expects queries to be handled by APIGuard which will
+ * perform additional 'view' action by itself. I.e. this API client sends
+ * `query_submit` and expects response of KonText's `view`.
+ */
+export class ConcApiSimplified implements IConcordanceApi<ConcQueryArgs>, WebDelegateApi {
+
+    protected readonly apiURL:string;
+
+    protected readonly useDataStream:boolean;
+
+    private readonly srcInfoService:CorpusInfoAPI;
+
+    protected readonly apiServices:IApiServices;
+
+    constructor(apiURL:string, useDataStream:boolean, apiServices:IApiServices) {
+        this.apiURL = apiURL;
+        this.useDataStream = useDataStream;
+        this.apiServices = apiServices;
+        this.srcInfoService = new CorpusInfoAPI(apiURL, apiServices);
+    }
+
+    getSupportedViewModes():Array<ViewMode> {
+        return [ViewMode.KWIC, ViewMode.SENT, ViewMode.ALIGN];
+    }
+
+    mkMatchQuery(lvar:QueryMatch, generator:[string, string]):string {
+        if (lvar.pos.length > 0) {
+            return mkLemmaMatchQuery(lvar, generator);
+
+        } else if (lvar.word) {
+            return mkWordMatchQuery(lvar);
+        }
+    }
+
+    getSourceDescription(tileId:number, lang:string, corpname:string):Observable<CorpusDetails> {
+        return this.srcInfoService.call(tileId, {
+            corpname: corpname,
+            format: 'json'
+        });
+    }
+
+    stateToArgs(state:ConcordanceMinState, lvar:QueryMatch, lvarIdx:number, otherLangCql:string):ConcQueryArgs {
+        const ans:ConcQueryArgs & PersistentConcArgs = {
+            type: 'concQueryArgs',
+            queries: [{
+                corpname: state.corpname,
+                qtype: 'advanced',
+                query: this.mkMatchQuery(lvar, state.posQueryGenerator),
+                pcq_pos_neg: 'pos',
+                include_empty: false,
+                default_attr: 'word'
+            }],
+            maincorp: state.corpname,
+            usesubcorp: state.subcname,
+            viewmode: state.viewMode,
+            shuffle: state.shuffle ? 1 : undefined,
+            attr_vmode: state.attr_vmode,
+            attrs: state.attrs,
+            ctxattrs: [],
+            base_viewattr: 'word',
+            structs: [],
+            refs: List.map(v => '=' + v.value, state.metadataAttrs),
+            pagesize: state.pageSize,
+            fromp: state.concordances[lvarIdx].loadPage,
+            text_types: {},
+            context: {
+                fc_lemword_window_type: undefined,
+                fc_lemword_wsize: undefined,
+                fc_lemword: undefined,
+                fc_lemword_type: undefined,
+                fc_pos_window_type: undefined,
+                fc_pos_wsize: undefined,
+                fc_pos: [],
+                fc_pos_type: undefined
+            },
+            kwicleftctx: -state.kwicLeftCtx,
+            kwicrightctx: state.kwicRightCtx
+        };
+
+        if (state.otherCorpname) {
+            ans.queries.push({
+                corpname: state.otherCorpname,
+                qtype: 'advanced',
+                query: otherLangCql || '',
+                pcq_pos_neg: 'pos',
+                include_empty: false,
+                default_attr: 'word'
+            });
+        }
+        return ans;
+    }
+
+    /**
+     * Create an action URL, action content type and action body args object based
+     * on provided API args.
+     */
+    private createActionUrl(args:ConcQueryArgs):[string, string, unknown] {
+        return tuple(URL.join(this.apiURL, 'query_submit'), 'application/json', args);
+    }
+
+    call(tileId:number, args:ConcQueryArgs):Observable<ConcResponse> {
+        const [url, contentType, argsBody] = this.createActionUrl(args);
+        const headers = this.apiServices.getApiHeaders(this.apiURL);
+        headers['X-Is-Web-App'] = '1';
+        return (
+            this.useDataStream ?
+            this.apiServices.dataStreaming().registerTileRequest<ConcViewResponse>({
+                tileId,
+                method: HTTP.Method.POST,
+                url,
+                body: argsBody,
+                contentType: 'application/json',
+                base64EncodeResult: false
+            })
+            : ajax$<ConcViewResponse>(
+                HTTP.Method.POST,
+                url,
+                argsBody,
+                {
+                    headers,
+                    withCredentials: true,
+                    contentType
+                }
+            )
+        ).pipe(
+            map(data => ({
+                concPersistenceID: data.conc_persistence_op_id,
+                messages: data.messages,
+                lines: convertLines(
+                    data.Lines,
+                    args.refs ?
+                        List.map(
+                            v => v.replace(/^=/, ''),
+                            args.refs
+                        ) :
+                        undefined
+                ),
+                kwicNumTokens: data.Lines.length > 0 ? parseInt(data.Lines[0].kwiclen) : 1,
+                concsize: data.concsize,
+                arf: data.result_arf,
+                ipm: data.result_relative_freq,
+                query: args.type === 'concQueryArgs' ? List.head(args.queries).query : null, // TODO filter type?
+                corpName: args.maincorp,
+                subcorpName: args.usesubcorp
+            }))
+        )
+    }
+
+    getBackLink(backlink:Backlink):Backlink {
+        return {
+            label: 'KonText',
+            method: HTTP.Method.GET,
+            ...(backlink || {}),
+            url: (backlink?.url ? backlink.url : this.apiURL) + '/view',
+        }
+    }
+}

--- a/src/js/api/vendor/kontext/concordance/v015/index.ts
+++ b/src/js/api/vendor/kontext/concordance/v015/index.ts
@@ -62,8 +62,7 @@ export class ConcApi implements IConcordanceApi<ConcQueryArgs|ConcViewArgs|Filte
     }
 
     getSourceDescription(tileId:number, lang:string, corpname:string):Observable<CorpusDetails> {
-        return this.srcInfoService.call({
-            tileId: tileId,
+        return this.srcInfoService.call(tileId, {
             corpname: corpname,
             format: 'json'
         });
@@ -178,7 +177,7 @@ export class ConcApi implements IConcordanceApi<ConcQueryArgs|ConcViewArgs|Filte
         }
     }
 
-    call(args:ConcQueryArgs|ConcViewArgs|FilterServerArgs|QuickFilterRequestArgs):Observable<ConcResponse> {
+    call(tileId:number, args:ConcQueryArgs|ConcViewArgs|FilterServerArgs|QuickFilterRequestArgs):Observable<ConcResponse> {
         const corpname = args.type === 'concQueryArgs' ? args.queries[0].corpname : args.corpname;
         const [url, contentType, argsBody] = this.createActionUrl(args);
         const headers = this.apiServices.getApiHeaders(this.apiURL);
@@ -186,7 +185,7 @@ export class ConcApi implements IConcordanceApi<ConcQueryArgs|ConcViewArgs|Filte
         return (args.type === 'concViewArgs' ?
             rxOf({
                 Q: [],
-                conc_persistence_op_id: args.q.substr(1),
+                conc_persistence_op_id: args.q.substring(1),
                 num_lines_in_groups: 0,
                 lines_groups_numbers: [],
                 query_overview: [],

--- a/src/js/api/vendor/kontext/corpusInfo.ts
+++ b/src/js/api/vendor/kontext/corpusInfo.ts
@@ -41,7 +41,6 @@ interface HTTPResponse {
 }
 
 export interface QueryArgs {
-    tileId:number;
     corpname:string;
     format:'json';
 }
@@ -62,7 +61,7 @@ export class CorpusInfoAPI implements DataApi<QueryArgs, CorpusDetails> {
         this.apiServices = apiServices;
     }
 
-    call(args:QueryArgs):Observable<CorpusDetails> {
+    call(tileId:number, args:QueryArgs):Observable<CorpusDetails> {
         const headers = this.apiServices.getApiHeaders(this.apiURL);
         headers['X-Is-Web-App'] = '1';
         return ajax$<HTTPResponse>(
@@ -78,7 +77,7 @@ export class CorpusInfoAPI implements DataApi<QueryArgs, CorpusDetails> {
             share(),
             map<HTTPResponse, CorpusDetails>(
                 (resp) => ({
-                    tileId: args.tileId,
+                    tileId,
                     title: resp.corpname,
                     description: resp.description,
                     author: '', // TODO

--- a/src/js/api/vendor/kontext/freqs.ts
+++ b/src/js/api/vendor/kontext/freqs.ts
@@ -114,7 +114,7 @@ export interface SingleCritQueryArgs extends CoreQueryArgs {
         this.apiServices = apiServices;
     }
 
-    call(args:SingleCritQueryArgs):Observable<HTTPResponse> {
+    call(tileId:number, args:SingleCritQueryArgs):Observable<HTTPResponse> {
         return ajax$<HTTPResponse>(
             'GET',
             this.apiURL + '/freqs',
@@ -150,8 +150,7 @@ export class KontextFreqDistribAPI implements IFreqDistribAPI<SingleCritQueryArg
     }
 
     getSourceDescription(tileId:number, lang:string, corpname:string):Observable<CorpusDetails> {
-        return this.srcInfoService.call({
-            tileId: tileId,
+        return this.srcInfoService.call(tileId, {
             corpname: corpname,
             format: 'json'
         });
@@ -193,7 +192,7 @@ export class KontextFreqDistribAPI implements IFreqDistribAPI<SingleCritQueryArg
         };
     }
 
-    call(args:SingleCritQueryArgs):Observable<APIResponse> {
+    call(tileId:number, args:SingleCritQueryArgs):Observable<APIResponse> {
         const headers = this.apiServices.getApiHeaders(this.apiURL);
         headers['X-Is-Web-App'] = '1';
         return ajax$<HTTPResponse>(
@@ -254,8 +253,7 @@ export class KontextMultiBlockFreqDistribAPI implements IMultiBlockFreqDistribAP
     }
 
     getSourceDescription(tileId:number, lang:string, corpname:string):Observable<CorpusDetails> {
-        return this.srcInfoService.call({
-            tileId: tileId,
+        return this.srcInfoService.call(tileId, {
             corpname: corpname,
             format: 'json'
         });
@@ -296,7 +294,7 @@ export class KontextMultiBlockFreqDistribAPI implements IMultiBlockFreqDistribAP
         };
     }
 
-    call(args:MultiCritQueryArgs):Observable<APIBlockResponse> {
+    call(tileId:number, args:MultiCritQueryArgs):Observable<APIBlockResponse> {
         return ajax$<HTTPResponse>(
             'GET',
             this.apiURL + '/freqs',

--- a/src/js/api/vendor/kontext/matchingDocs.ts
+++ b/src/js/api/vendor/kontext/matchingDocs.ts
@@ -91,15 +91,14 @@ export class KontextMatchingDocsAPI implements MatchingDocsAPI<KontextMatchingDo
     }
 
     getSourceDescription(tileId:number, lang:string, corpname:string):Observable<CorpusDetails> {
-        return this.srcInfoService.call({
-            tileId: tileId,
+        return this.srcInfoService.call(tileId, {
             corpname: corpname,
             format: 'json'
         });
     }
 
-    call(args:KontextMatchingDocsQueryArgs):Observable<APIResponse> {
-        return this.freqApi.call(args).pipe(
+    call(tileId:number, args:KontextMatchingDocsQueryArgs):Observable<APIResponse> {
+        return this.freqApi.call(tileId, args).pipe(
             map<HTTPResponse, APIResponse>(resp => ({
                 data: List.map(
                     v => ({
@@ -129,8 +128,8 @@ export class KontextLiveattrsMatchingDocsAPI extends KontextMatchingDocsAPI {
         };
     }
 
-    call(args:KontextMatchingDocsQueryArgs):Observable<APIResponse> {
-        return super.call(args).pipe(
+    call(tileId:number, args:KontextMatchingDocsQueryArgs):Observable<APIResponse> {
+        return super.call(tileId, args).pipe(
             mergeMap(freq =>
                 ajax$<FillHTTPResponse>(
                     HTTP.Method.POST,

--- a/src/js/api/vendor/kontext/speeches.ts
+++ b/src/js/api/vendor/kontext/speeches.ts
@@ -71,14 +71,13 @@ export class SpeechesApi implements ResourceApi<SpeechReqArgs, SpeechResponse>, 
     }
 
     getSourceDescription(tileId:number, lang:string, corpname:string):Observable<CorpusDetails> {
-        return this.srcInfoService.call({
-            tileId: tileId,
+        return this.srcInfoService.call(tileId, {
             corpname: corpname,
             format: 'json'
         });
     }
 
-    call(args:SpeechReqArgs):Observable<SpeechResponse> {
+    call(tileId:number, args:SpeechReqArgs):Observable<SpeechResponse> {
         const headers = this.apiServices.getApiHeaders(this.apiUrl);
         headers['X-Is-Web-App'] = '1';
         if (args.pos !== undefined) {

--- a/src/js/api/vendor/kontext/switchMainCorp.ts
+++ b/src/js/api/vendor/kontext/switchMainCorp.ts
@@ -47,7 +47,7 @@ export class SwitchMainCorpApi implements ISwitchMainCorpApi {
         this.apiServices = apiServices;
     }
 
-    call(args:SwitchMainCorpArgs):Observable<SwitchMainCorpResponse> {
+    call(tileId:number, args:SwitchMainCorpArgs):Observable<SwitchMainCorpResponse> {
         const headers = this.apiServices.getApiHeaders(this.apiURL);
         headers['X-Is-Web-App'] = '1';
         return ajax$<HTTPResponse>(

--- a/src/js/api/vendor/kontext/timeDistrib.ts
+++ b/src/js/api/vendor/kontext/timeDistrib.ts
@@ -53,8 +53,7 @@ export class KontextTimeDistribApi implements TimeDistribApi, WebDelegateApi {
     }
 
     getSourceDescription(tileId:number, lang:string, corpname:string):Observable<CorpusDetails> {
-        return this.srcInfoService.call({
-            tileId: tileId,
+        return this.srcInfoService.call(tileId, {
             corpname: corpname,
             format: 'json'
         });
@@ -97,8 +96,8 @@ export class KontextTimeDistribApi implements TimeDistribApi, WebDelegateApi {
         }
     }
 
-    call(queryArgs:TimeDistribArgs):Observable<TimeDistribResponse> {
-        return this.freqApi.call({
+    call(tileId:number, queryArgs:TimeDistribArgs):Observable<TimeDistribResponse> {
+        return this.freqApi.call(tileId, {
             corpname: queryArgs.corpName,
             usesubcorp: queryArgs.subcorpName,
             q: `~${queryArgs.concIdent}`,

--- a/src/js/api/vendor/kontext/wordForms.ts
+++ b/src/js/api/vendor/kontext/wordForms.ts
@@ -44,8 +44,8 @@ export class WordFormsAPI implements IWordFormsApi, WebDelegateApi {
         this.srcInfoService = new CorpusInfoAPI(apiURL, apiServices);
     }
 
-    call(args:RequestConcArgs):Observable<Response> {
-        return this.fapi.call({
+    call(tileId:number, args:RequestConcArgs):Observable<Response> {
+        return this.fapi.call(tileId, {
             corpname: args.corpName,
             usesubcorp: args.subcorpName,
             q: '~' + args.concPersistenceID,
@@ -75,8 +75,7 @@ export class WordFormsAPI implements IWordFormsApi, WebDelegateApi {
     }
 
     getSourceDescription(tileId:number, lang:string, corpname:string):Observable<CorpusDetails> {
-        return this.srcInfoService.call({
-            tileId: tileId,
+        return this.srcInfoService.call(tileId, {
             corpname: corpname,
             format: 'json'
         });

--- a/src/js/api/vendor/kontext/wordList.ts
+++ b/src/js/api/vendor/kontext/wordList.ts
@@ -53,7 +53,7 @@ export class WordListAPI implements DataApi<WordListArgs, WordListResponse> {
 		this.apiServices = apiServices;
 	}
 
-	call(args:WordListArgs):Observable<WordListResponse> {
+	call(tileId:number, args:WordListArgs):Observable<WordListResponse> {
 		const headers = this.apiServices.getApiHeaders(this.url);
         headers['X-Is-Web-App'] = '1';
 		return ajax$<WordListResponse>(

--- a/src/js/api/vendor/lcc/concordance.ts
+++ b/src/js/api/vendor/lcc/concordance.ts
@@ -101,7 +101,7 @@ export class ConcApi implements IConcordanceApi<RequestArgs> {
         };
     }
 
-    call(args:RequestArgs):Observable<ConcResponse> {
+    call(tileId:number, args:RequestArgs):Observable<ConcResponse> {
         return ajax$<HTTPResponse>(
             'GET',
             this.apiURL + `/sentences/${args.corpname}/sentences/${args.word}`,
@@ -148,8 +148,7 @@ export class ConcApi implements IConcordanceApi<RequestArgs> {
     }
 
     getSourceDescription(tileId:number, lang:string, corpname:string):Observable<CorpusDetails> {
-        return this.srcInfoService.call({
-            tileId: tileId,
+        return this.srcInfoService.call(tileId, {
             corpname: corpname
         });
     }

--- a/src/js/api/vendor/lcc/cooccurrences.ts
+++ b/src/js/api/vendor/lcc/cooccurrences.ts
@@ -85,7 +85,7 @@ export class LccCollAPI implements CollocationApi<CollRequestArgs> {
         });
     }
 
-    call(queryArgs:CollRequestArgs):Observable<CollApiResponse> {
+    call(tileId:number, queryArgs:CollRequestArgs):Observable<CollApiResponse> {
         return ajax$<HttpApiResponse>(
             'GET',
             this.apiURL + `/coocurrences/${queryArgs.corpus}/cooccurrences/${queryArgs.word}/`,

--- a/src/js/api/vendor/lcc/corpusInfo.ts
+++ b/src/js/api/vendor/lcc/corpusInfo.ts
@@ -39,7 +39,6 @@ type HTTPResponse = Array<CorpusInfo>;
 
 
 export interface QueryArgs {
-    tileId:number;
     corpname:string;
 }
 
@@ -58,7 +57,7 @@ export class CorpusInfoAPI implements DataApi<QueryArgs, SourceDetails> {
         this.corpora = {};
     }
 
-    call(args:QueryArgs):Observable<CorpusDetails> {
+    call(tileId:number, args:QueryArgs):Observable<CorpusDetails> {
         return (this.corpora[args.corpname] ?
             rxOf(this.corpora[args.corpname]) :
             ajax$<HTTPResponse>(
@@ -100,7 +99,7 @@ export class CorpusInfoAPI implements DataApi<QueryArgs, SourceDetails> {
         ).pipe(
             map(
                 (info) => ({
-                    tileId: args.tileId,
+                    tileId,
                     title: info.corpusName,
                     description: info.description,
                     author: '',

--- a/src/js/api/vendor/lcc/wordSim.ts
+++ b/src/js/api/vendor/lcc/wordSim.ts
@@ -83,7 +83,7 @@ export class LccCoocSimApi implements IWordSimApi<LccCoocSimApiArgs> {
         });
     }
 
-    call(queryArgs:LccCoocSimApiArgs):Observable<WordSimApiResponse> {
+    call(tileId:number, queryArgs:LccCoocSimApiArgs):Observable<WordSimApiResponse> {
         return new Observable<string>(observer => {
             try {
                 const url = this.apiURL + `/similarity/${queryArgs.corpus}/coocsim/${queryArgs.word}`;

--- a/src/js/api/vendor/mquery/corpusInfo.ts
+++ b/src/js/api/vendor/mquery/corpusInfo.ts
@@ -48,7 +48,6 @@ interface HTTPResponse {
 }
 
 export interface QueryArgs {
-    tileId:number;
     corpname:string;
     lang:string;
 }
@@ -69,7 +68,7 @@ export class CorpusInfoAPI implements DataApi<QueryArgs, CorpusDetails> {
         this.apiServices = apiServices;
     }
 
-    call(args:QueryArgs):Observable<CorpusDetails> {
+    call(tileId:number, args:QueryArgs):Observable<CorpusDetails> {
         return ajax$<HTTPResponse>(
             HTTP.Method.GET,
             this.apiURL + `/info/${args.corpname}`,
@@ -83,7 +82,7 @@ export class CorpusInfoAPI implements DataApi<QueryArgs, CorpusDetails> {
             share(),
             map<HTTPResponse, CorpusDetails>(
                 (resp) => ({
-                    tileId: args.tileId,
+                    tileId,
                     title: resp.corpus.data.corpname,
                     description: resp.corpus.data.description,
                     author: '', // TODO

--- a/src/js/api/vendor/mquery/freqs.ts
+++ b/src/js/api/vendor/mquery/freqs.ts
@@ -72,7 +72,7 @@ export class MQueryFreqDistribAPI implements IFreqDistribAPI<MQueryFreqArgs> {
     }
 
     getSourceDescription(tileId:number, lang:string, corpname:string):Observable<CorpusDetails> {
-        return this.srcInfoService.call({tileId, corpname, lang});
+        return this.srcInfoService.call(tileId, {corpname, lang});
     }
 
     createBacklink(state:MinSingleCritFreqState, backlink:Backlink, concId:string):BacklinkWithArgs<{}> {
@@ -105,7 +105,7 @@ export class MQueryFreqDistribAPI implements IFreqDistribAPI<MQueryFreqArgs> {
      * For args.path == 'text-types', multiple values represent whole different thing
      * (freqs for different domains) - so in that case, we don't group anything.
      */
-    call(args:MQueryFreqArgs):Observable<APIResponse> {
+    call(tileId:number, args:MQueryFreqArgs):Observable<APIResponse> {
         return ajax$<HTTPResponse>(
             'GET',
             this.apiURL + `/${args.path}/${args.corpname}`,

--- a/src/js/api/vendor/mquery/syntacticColls.ts
+++ b/src/js/api/vendor/mquery/syntacticColls.ts
@@ -95,10 +95,10 @@ export class MquerySyntacticCollsAPI implements SyntacticCollsApi<SCollsRequest>
     }
 
     getSourceDescription(tileId:number, lang:string, corpname:string):Observable<SourceDetails> {
-        return this.srcInfoService.call({tileId, corpname, lang});
+        return this.srcInfoService.call(tileId, {corpname, lang});
     }
 
-    call(request:SCollsRequest):Observable<[SCollsQueryType, SCollsData]> {
+    call(tileId:number, request:SCollsRequest):Observable<[SCollsQueryType, SCollsData]> {
         const url = this.isScollex ?
         this.apiURL + `/query/${request.params.corpname}/${request.params.queryType}` :
         this.apiURL + `/scoll/${request.params.corpname}/${request.params.queryType}`
@@ -168,7 +168,7 @@ export class MquerySyntacticCollsExamplesApi implements SyntacticCollsExamplesAp
         };
     }
 
-    call(request:SCERequestArgs):Observable<SCollsExamples> {
+    call(tileId:number, request:SCERequestArgs):Observable<SCollsExamples> {
         return ajax$<SCollsExamples>(
             'GET',
             this.apiURL + `/conc-examples/${request.params.corpname}`,

--- a/src/js/api/vendor/mquery/timeDistrib.ts
+++ b/src/js/api/vendor/mquery/timeDistrib.ts
@@ -72,14 +72,14 @@ export class MQueryTimeDistribStreamApi implements TimeDistribApi {
     }
 
     getSourceDescription(tileId:number, lang:string, corpname:string):Observable<CorpusDetails> {
-        return this.srcInfoService.call({tileId, corpname, lang});
+        return this.srcInfoService.call(tileId, {corpname, lang});
     }
 
     createBackLink(backlink:Backlink, corpname:string, concId:string, origQuery:string):BacklinkWithArgs<{}> {
         return null
     }
 
-    call(queryArgs:TimeDistribArgs):Observable<TimeDistribResponse> {
+    call(tileId:number, queryArgs:TimeDistribArgs):Observable<TimeDistribResponse> {
         return new Observable(o => {
             const args = pipe(
                 {

--- a/src/js/api/vendor/mquery/wordForms.ts
+++ b/src/js/api/vendor/mquery/wordForms.ts
@@ -48,7 +48,7 @@ export class WordFormsAPI implements IWordFormsApi {
         this.srcInfoService = new CorpusInfoAPI(apiURL, apiServices);
     }
 
-    call(args:RequestArgs):Observable<Response> {
+    call(tileId:number, args:RequestArgs):Observable<Response> {
         const params = {
             lemma: args.lemma,
             pos: args.pos.join(" "),
@@ -79,7 +79,7 @@ export class WordFormsAPI implements IWordFormsApi {
     }
 
     getSourceDescription(tileId:number, lang:string, corpname:string):Observable<CorpusDetails> {
-        return this.srcInfoService.call({tileId, corpname, lang});
+        return this.srcInfoService.call(tileId, {corpname, lang});
     }
 
     createBacklink(args:RequestArgs, backlink:Backlink) {

--- a/src/js/api/vendor/noske/collocations.ts
+++ b/src/js/api/vendor/noske/collocations.ts
@@ -108,8 +108,7 @@ export class NoskeCollAPI implements CollocationApi<CollApiArgs> {
     }
 
     getSourceDescription(tileId:number, lang:string, corpname:string):Observable<SourceDetails> {
-        return this.srcInfoService.call({
-            tileId: tileId,
+        return this.srcInfoService.call(tileId, {
             corpname: corpname,
             struct_attr_stats: 1,
             subcorpora: 1,
@@ -117,7 +116,7 @@ export class NoskeCollAPI implements CollocationApi<CollApiArgs> {
         });
     }
 
-    call(queryArgs:CollApiArgs):Observable<CollApiResponse> {
+    call(tileId:number, queryArgs:CollApiArgs):Observable<CollApiResponse> {
         return ajax$<HttpApiResponse>(
             'GET',
             this.apiURL + '/collx',

--- a/src/js/api/vendor/noske/concordance.ts
+++ b/src/js/api/vendor/noske/concordance.ts
@@ -237,7 +237,7 @@ export class ConcApi implements IConcordanceApi<RequestArgs> {
         return this.apiURL + '/' + (args.q ? 'view' : 'first');
     }
 
-    call(args:RequestArgs|FilterRequestArgs):Observable<ConcResponse> {
+    call(tileId:number, args:RequestArgs|FilterRequestArgs):Observable<ConcResponse> {
         return ajax$<HTTPResponse>(
             'GET',
             this.createActionUrl(args),
@@ -265,8 +265,7 @@ export class ConcApi implements IConcordanceApi<RequestArgs> {
     }
 
     getSourceDescription(tileId:number, lang:string, corpname:string):Observable<CorpusDetails> {
-        return this.srcInfoService.call({
-            tileId: tileId,
+        return this.srcInfoService.call(tileId, {
             corpname: corpname,
             struct_attr_stats: 1,
             subcorpora: 1,

--- a/src/js/api/vendor/noske/corpusInfo.ts
+++ b/src/js/api/vendor/noske/corpusInfo.ts
@@ -90,7 +90,6 @@ interface HTTPResponse extends HTTPApiResponse {
 }
 
 export interface QueryArgs {
-    tileId:number;
     corpname:string;
     struct_attr_stats:1;
     subcorpora:1;
@@ -114,7 +113,7 @@ export class CorpusInfoAPI implements DataApi<QueryArgs, SourceDetails> {
         this.apiServices = apiServices;
     }
 
-    call(args:QueryArgs):Observable<CorpusDetails> {
+    call(tileId:number, args:QueryArgs):Observable<CorpusDetails> {
         return ajax$<HTTPResponse>(
             'GET',
             this.apiURL + '/corp_info',
@@ -128,7 +127,7 @@ export class CorpusInfoAPI implements DataApi<QueryArgs, SourceDetails> {
             share(),
             map(
                 (resp) => ({
-                    tileId: args.tileId,
+                    tileId,
                     title: resp.name,
                     description: resp.info,
                     author: '',

--- a/src/js/api/vendor/noske/freqs.ts
+++ b/src/js/api/vendor/noske/freqs.ts
@@ -118,8 +118,7 @@ export class NoskeFreqDistribAPI implements IFreqDistribAPI<SingleCritQueryArgs>
     }
 
     getSourceDescription(tileId:number, lang:string, corpname:string):Observable<CorpusDetails> {
-        return this.srcInfoService.call({
-            tileId: tileId,
+        return this.srcInfoService.call(tileId, {
             corpname: corpname,
             struct_attr_stats: 1,
             subcorpora: 1,
@@ -159,7 +158,7 @@ export class NoskeFreqDistribAPI implements IFreqDistribAPI<SingleCritQueryArgs>
         };
     }
 
-    call(args:SingleCritQueryArgs):Observable<APIResponse> {
+    call(tileId:number, args:SingleCritQueryArgs):Observable<APIResponse> {
         return ajax$<HTTPResponse>(
             'GET',
             this.apiURL + '/freqs',
@@ -209,8 +208,7 @@ export class NoskeMultiBlockFreqDistribAPI implements IMultiBlockFreqDistribAPI<
     }
 
     getSourceDescription(tileId:number, lang:string, corpname:string):Observable<CorpusDetails> {
-        return this.srcInfoService.call({
-            tileId: tileId,
+        return this.srcInfoService.call(tileId, {
             corpname: corpname,
             struct_attr_stats: 1,
             subcorpora: 1,
@@ -250,7 +248,7 @@ export class NoskeMultiBlockFreqDistribAPI implements IMultiBlockFreqDistribAPI<
         };
     }
 
-    call(args:MultiCritQueryArgs):Observable<APIBlockResponse> {
+    call(tileId:number, args:MultiCritQueryArgs):Observable<APIBlockResponse> {
         return ajax$<HTTPResponse>(
             'GET',
             this.apiURL + '/freqs',

--- a/src/js/api/vendor/noske/timeDistrib.ts
+++ b/src/js/api/vendor/noske/timeDistrib.ts
@@ -54,8 +54,7 @@ export class NoskeTimeDistribApi implements TimeDistribApi {
     }
 
     getSourceDescription(tileId:number, lang:string, corpname:string):Observable<CorpusDetails> {
-        return this.srcInfoService.call({
-            tileId: tileId,
+        return this.srcInfoService.call(tileId, {
             corpname: corpname,
             struct_attr_stats: 1,
             subcorpora: 1,
@@ -78,9 +77,9 @@ export class NoskeTimeDistribApi implements TimeDistribApi {
             null;
     }
 
-    call(queryArgs:TimeDistribArgs):Observable<TimeDistribResponse> {
+    call(tileId:number, queryArgs:TimeDistribArgs):Observable<TimeDistribResponse> {
 
-        return this.freqApi.call({
+        return this.freqApi.call(tileId, {
             corpname: queryArgs.corpName,
             usesubcorp: queryArgs.subcorpName,
             q: processConcId(queryArgs.concIdent),

--- a/src/js/api/vendor/treq/index.ts
+++ b/src/js/api/vendor/treq/index.ts
@@ -164,7 +164,7 @@ class TreqAPICaller {
         )).sort((x1, x2) => x2.score - x1.score);
     }
 
-    call(args:RequestArgs):Observable<TranslationResponse> {
+    call(tileId:number, args:RequestArgs):Observable<TranslationResponse> {
         const headers = this.appServices.getApiHeaders(this.apiURL);
         headers['X-Is-Web-App'] = '1';
         return ajax$<HTTPResponse>(

--- a/src/js/api/vendor/wdglance/freqDbSourceInfo.ts
+++ b/src/js/api/vendor/wdglance/freqDbSourceInfo.ts
@@ -26,7 +26,6 @@ import { IApiServices } from '../../../appServices.js';
 
 
 export interface FreqDbSourceInfoArgs {
-    tileId:number;
     queryType:QueryType;
     domain:string;
     corpname:string;
@@ -43,7 +42,7 @@ export class InternalResourceInfoApi implements DataApi<FreqDbSourceInfoArgs, So
         this.apiServices = apiServices;
     }
 
-    call(args:FreqDbSourceInfoArgs):Observable<SourceDetails> {
+    call(tileId:number, args:FreqDbSourceInfoArgs):Observable<SourceDetails> {
         return ajax$<{result:SourceDetails}>(
             'GET',
             this.apiURL + HTTPAction.SOURCE_INFO,
@@ -55,7 +54,7 @@ export class InternalResourceInfoApi implements DataApi<FreqDbSourceInfoArgs, So
 
         ).pipe(
             map(
-                resp => ({...resp.result, tileId: args.tileId})
+                resp => ({...resp.result, tileId})
             )
         )
     };

--- a/src/js/api/vendor/wdglance/html.ts
+++ b/src/js/api/vendor/wdglance/html.ts
@@ -62,7 +62,7 @@ export class RawHtmlAPI implements IGeneralHtmlAPI<HtmlApiArgs>, WebDelegateApi 
         return true;
     }
 
-    call(queryArgs:HtmlApiArgs):Observable<string|null> {
+    call(tileId:number, queryArgs:HtmlApiArgs):Observable<string|null> {
         return ajax$<string>(
             'GET',
             this.apiURL,

--- a/src/js/api/vendor/wdglance/similarFreq.ts
+++ b/src/js/api/vendor/wdglance/similarFreq.ts
@@ -33,7 +33,7 @@ interface HTTPResponse {
 
 export class SimilarFreqWordsNullAPI implements SimilarFreqDbAPI {
 
-    call(args:RequestArgs):Observable<Response> {
+    call(tileId:number, args:RequestArgs):Observable<Response> {
         return rxOf({result: []});
     }
 }
@@ -50,7 +50,7 @@ export class SimilarFreqWordsAPI implements SimilarFreqDbAPI {
         this.apiServices = apiServices;
     }
 
-    call(args:RequestArgs):Observable<Response> {
+    call(tileId:number, args:RequestArgs):Observable<Response> {
         return ajax$<HTTPResponse>(
             'GET',
             this.apiURL + HTTPAction.SIMILAR_FREQ_WORDS,

--- a/src/js/api/vendor/wdglance/wordForms.ts
+++ b/src/js/api/vendor/wdglance/wordForms.ts
@@ -46,7 +46,7 @@ export class WordFormsWdglanceAPI implements IWordFormsApi {
         this.srcInfoApi = srcInfoURL ? new InternalResourceInfoApi(srcInfoURL, apiServices) : null;
     }
 
-    call(args:RequestArgs):Observable<Response> {
+    call(tileId:number, args:RequestArgs):Observable<Response> {
         return ajax$<HTTPResponse>(
             HTTP.Method.GET,
             this.apiUrl + HTTPAction.WORD_FORMS,
@@ -70,14 +70,13 @@ export class WordFormsWdglanceAPI implements IWordFormsApi {
 
     getSourceDescription(tileId:number, domain:string, corpname:string):Observable<SourceDetails> {
         return this.srcInfoApi ?
-            this.srcInfoApi.call({
-                tileId: tileId,
+            this.srcInfoApi.call(tileId, {
                 corpname: corpname,
                 queryType: QueryType.SINGLE_QUERY,
                 domain: domain
             }) :
              rxOf({
-                tileId: tileId,
+                tileId,
                 title: 'Word forms generated from an internal database (no additional details available)',
                 description: '',
                 author: '',

--- a/src/js/api/vendor/wdglance/wordSim.ts
+++ b/src/js/api/vendor/wdglance/wordSim.ts
@@ -86,8 +86,7 @@ export class CNCWord2VecSimApi implements IWordSimApi<CNCWord2VecSimApiArgs> {
 
     getSourceDescription(tileId:number, domain:string, corpname:string):Observable<SourceDetails> {
         return this.srcInfoApi ?
-            this.srcInfoApi.call({
-                tileId: tileId,
+            this.srcInfoApi.call(tileId, {
                 corpname: corpname,
                 domain: domain,
                 queryType: QueryType.SINGLE_QUERY
@@ -104,7 +103,7 @@ export class CNCWord2VecSimApi implements IWordSimApi<CNCWord2VecSimApiArgs> {
             });
     }
 
-    call(queryArgs:CNCWord2VecSimApiArgs):Observable<WordSimApiResponse> {
+    call(tileId:number, queryArgs:CNCWord2VecSimApiArgs):Observable<WordSimApiResponse> {
         const url = this.apiURL + '/corpora/' + queryArgs.corpus + '/similarWords/' + queryArgs.model +
                 '/' + queryArgs.word + (queryArgs.pos ? '/' + queryArgs.pos : '');
         return ajax$<HTTPResponse>(

--- a/src/js/api/vendor/wiktionary/html.ts
+++ b/src/js/api/vendor/wiktionary/html.ts
@@ -65,7 +65,7 @@ export class WiktionaryHtmlAPI implements IGeneralHtmlAPI<WiktionaryApiArgs>, We
             input;
     }
 
-    call(queryArgs:WiktionaryApiArgs):Observable<string|null> {
+    call(tileId:number, queryArgs:WiktionaryApiArgs):Observable<string|null> {
         return ajax$<string>(
             'GET',
             this.apiURL,

--- a/src/js/app.ts
+++ b/src/js/app.ts
@@ -39,6 +39,7 @@ import { ViewUtils, IFullActionControl } from 'kombo';
 import { IAppServices } from './appServices.js';
 import { mkTileFactory } from './page/tileLoader.js';
 import { List, pipe, Dict } from 'cnc-tskit';
+import { DataStreaming } from './page/streaming.js';
 
 
 interface AttachTileArgs {

--- a/src/js/page/streaming.ts
+++ b/src/js/page/streaming.ts
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2025 Tomas Machalek <tomas.machalek@gmail.com>
+ * Copyright 2025 Institute of the Czech National Corpus,
+ *                Faculty of Arts, Charles University
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { HTTP, List, pipe, tuple } from 'cnc-tskit';
+import { Observable, Subject } from 'rxjs';
+import { concatMap, filter, first, map, scan, share } from 'rxjs/operators';
+import { ajax$, encodeArgs } from './ajax.js';
+
+
+interface TileRequest {
+    tileId:number;
+    url:string;
+    method:HTTP.Method,
+    body:unknown;
+    contentType:string;
+    base64EncodeResult:boolean;
+}
+
+interface EventItem<T = unknown> {
+    tileId:number;
+    data:T;
+}
+
+
+export class DataStreaming {
+
+    private requestSubject:Subject<TileRequest>;
+
+    private responseStream:Observable<EventItem>;
+
+    constructor(tileIds:Array<string|number>) {
+        this.requestSubject = new Subject<TileRequest>();
+        this.responseStream = this.requestSubject.pipe(
+            scan(
+                (acc, value) => {
+                    if (acc.get(value.tileId) === undefined) {
+                        acc.set(value.tileId, value);
+                    }
+                    return acc;
+                },
+                new Map(
+                    pipe(
+                        tileIds,
+                        List.map<number|string, [number, TileRequest|undefined]>(
+                            v => tuple(typeof(v) === 'string' ? parseInt(v) : v, undefined),
+                        )
+                    )
+                )
+            ),
+            first(
+                v => {
+                    for (const [key, value] of v) {
+                        if (value === undefined) {
+                            return false;
+                        }
+                    }
+                    return true
+                }
+            ),
+            concatMap(
+                tileReqMap => ajax$<{id:string}>(
+                    HTTP.Method.PUT,
+                    "http://wag.korpus.test/apiguard/wstream",
+                    {
+                        requests: pipe(
+                            Array.from(tileReqMap.entries()),
+                            List.map(
+                                ([k, tileReq]) => tileReq
+                            )
+                        )
+                    },
+                    {
+                        contentType: 'application/json'
+                    }
+                ).pipe(
+                    map(
+                        resp => tuple(tileReqMap, resp)
+                    )
+                )
+            ),
+            concatMap(
+                ([tileReqMap, resp]) => new Observable<EventItem>(
+                    observer => {
+                        const evtSrc = new EventSource(
+                            `http://wag.korpus.test/apiguard/wstream/${resp.id}`
+                        );
+                        tileReqMap.forEach(
+                            (val, key) => {
+                                evtSrc.addEventListener(`DataTile-${val.tileId}`, evt => {
+                                    if (val.contentType == 'application/json') {
+                                        observer.next({
+                                            data: JSON.parse(evt.data),
+                                            tileId: val.tileId
+                                        });
+
+                                    } else if (val.base64EncodeResult && typeof evt.data === 'string') {
+                                        const tmp = atob(evt.data);
+                                        observer.next({
+                                            data: tmp,
+                                            tileId: val.tileId
+                                        })
+
+                                    } else {
+                                        observer.next({
+                                            data: val.contentType == 'application/json' ?
+                                                JSON.parse(evt.data) : evt.data,
+                                            tileId: val.tileId
+                                        })
+                                    }
+                                });
+                            }
+                        );
+                        evtSrc.addEventListener('close', () => {
+                            observer.complete();
+                            evtSrc.close();
+                        })
+                        evtSrc.onerror = v => {
+                            console.error(v);
+                            if (evtSrc.readyState === EventSource.CLOSED) {
+                                evtSrc.close();
+                                observer.complete();
+                            }
+                        }
+                    }
+                )
+            ),
+            share()
+        );
+        this.responseStream.subscribe({
+            error: error => {
+                console.log('response stream error: ', error)
+            }
+        });
+    }
+
+
+    registerTileRequest<T>(entry:TileRequest):Observable<T> {
+        const updEntry = {...entry};
+        if (entry.body) {
+            if (updEntry.method === HTTP.Method.GET) {
+                const tmp = updEntry.url.split('?');
+                const encArgs = encodeArgs(entry.body);
+                updEntry.url = tmp.length === 1 ?
+                    updEntry.url + '?' + encArgs :
+                    updEntry.url + '&' + encArgs;
+                updEntry.body = '';
+
+            } else if (updEntry.contentType === 'application/json') {
+                updEntry.body = JSON.stringify(updEntry.body);
+
+            } else {
+                updEntry.body = encodeArgs(entry.body);
+            }
+        }
+        this.requestSubject.next(updEntry);
+        return this.responseStream.pipe(
+            filter((response:EventItem<T>) => response.tileId === entry.tileId),
+            map(response => response.data as T)
+        );
+    }
+}

--- a/src/js/page/tile.ts
+++ b/src/js/page/tile.ts
@@ -24,6 +24,7 @@ import { Theme } from './theme.js';
 import { IAppServices } from '../appServices.js';
 import { HTTP, List } from 'cnc-tskit';
 import { MainPosAttrValues } from '../conf/index.js';
+import { DataStreaming } from './streaming.js';
 
 
 export interface Backlink {
@@ -129,6 +130,8 @@ export interface TileConf {
      * Defines tiles which can be used as sources of subqueries
      */
     compatibleSubqProviders?:Array<string>;
+
+    useDataStream?:boolean;
 }
 
 /**
@@ -340,6 +343,8 @@ export interface TileFactoryArgs<T> {
     conf:T;
 
     mainPosAttr:MainPosAttrValues;
+
+    useDataStream:boolean;
 }
 
 /**

--- a/src/js/page/tileLoader.ts
+++ b/src/js/page/tileLoader.ts
@@ -26,6 +26,7 @@ import { Theme } from './theme.js';
 import { LayoutManager } from './layout.js';
 import { QueryType, RecognizedQueries } from '../query/index.js';
 import { EmptyTile } from '../tiles/core/empty.js';
+import { DataStreaming } from './streaming.js';
 
 declare var require:any;
 
@@ -127,6 +128,7 @@ export const mkTileFactory = (
                 conf,
                 isBusy: true,
                 mainPosAttr: layoutManager.getLayoutMainPosAttr(queryType),
+                useDataStream: !!conf.useDataStream
             };
             const errs = tileFactory.sanityCheck(args);
             if (!List.empty(errs)) {

--- a/src/js/server/apiServices.ts
+++ b/src/js/server/apiServices.ts
@@ -18,17 +18,22 @@
 
 import { Dict } from 'cnc-tskit';
 import { ClientStaticConf, CommonTextStructures } from '../conf/index.js'
+import { IApiServices } from '../appServices.js';
+import { DataStreaming } from '../page/streaming.js';
 
 
-export class ApiServices {
+export class ApiServices implements IApiServices {
 
     private readonly apiKeyStorage:{[url:string]:{[header:string]:string}};
 
     private readonly clientConf:ClientStaticConf;
 
-    constructor(clientConf:ClientStaticConf) {
+    private readonly dataStreamingImpl:DataStreaming;
+
+    constructor(clientConf:ClientStaticConf, dataStreaming:DataStreaming) {
         this.apiKeyStorage = {};
         this.clientConf = clientConf;
+        this.dataStreamingImpl = dataStreaming;
     }
 
     getApiHeaders(apiUrl:string) {
@@ -64,4 +69,8 @@ export class ApiServices {
         }
         this.apiKeyStorage[apiUrl][headerName] = key;
     }
+
+     dataStreaming():DataStreaming {
+        return this.dataStreamingImpl;
+     }
 }

--- a/src/js/server/freqdb/backends/kontext.ts
+++ b/src/js/server/freqdb/backends/kontext.ts
@@ -137,8 +137,7 @@ export class KontextFreqDB implements IFreqDB {
     }
 
     getSourceDescription(uiLang:string, corpname:string):Observable<CorpusDetails> {
-        return this.srcInfoService.call({
-            tileId: -1,
+        return this.srcInfoService.call(-1, {
             corpname: corpname,
             format: 'json'
         });

--- a/src/js/server/index.ts
+++ b/src/js/server/index.ts
@@ -42,6 +42,7 @@ import { PackageInfo } from '../types.js';
 import { QueryActionWriter } from './actionLog/logWriter.js';
 import { ApiServices } from './apiServices.js';
 import { initLogging } from './logging.js';
+import { DataStreaming } from '../page/streaming.js';
 
 
 function loadTilesConf(clientConf:ClientStaticConf):Observable<DomainAnyTileConf> {
@@ -155,7 +156,7 @@ forkJoin([ // load core configs
 
         const db:WordDatabases = new WordDatabases(
             serverConf.freqDB,
-            new ApiServices(clientConf)
+            new ApiServices(clientConf, new DataStreaming([]))
         );
 
         const toolbar = createToolbarInstance(serverConf.toolbar);

--- a/src/js/server/routes/common.ts
+++ b/src/js/server/routes/common.ts
@@ -33,6 +33,7 @@ import { RecognizedQueries } from '../../query/index.js';
 import { WdglanceMainProps } from '../../views/main.js';
 import { ErrPageProps } from '../../views/error.js';
 import { TileGroup } from '../../page/layout.js';
+import { DataStreaming } from '../../page/streaming.js';
 
 /**
  * Obtain value (or values if a key is provided multiple times) from
@@ -149,6 +150,7 @@ export function createHelperServices(services:Services, uiLang:string):[ViewUtil
             staticUrlCreator: viewUtils.createStaticUrl,
             actionUrlCreator: viewUtils.createActionUrl,
             dataReadability: {metadataMapping: {}, commonStructures: {}},
+            dataStreaming: new DataStreaming([]),
             apiHeadersMapping: services.clientConf.apiHeaders || {},
             mobileModeTest: ()=>false
         })

--- a/src/js/server/routes/index.ts
+++ b/src/js/server/routes/index.ts
@@ -40,6 +40,7 @@ import { emptyValue } from '../toolbar/empty.js';
 import { importQueryPos } from '../../postag.js';
 import { ServerHTTPRequestError } from '../request.js';
 import { logAction } from '../actionLog/common.js';
+import { DataStreaming } from '../../page/streaming.js';
 
 const LANG_COOKIE_TTL = 3600 * 24 * 365;
 
@@ -449,6 +450,7 @@ export const wdgRouter = (services:Services) => (app:Express) => {
             actionUrlCreator: viewUtils.createActionUrl,
             dataReadability: {metadataMapping: {}, commonStructures: {}},
             apiHeadersMapping: services.clientConf.apiHeaders || {},
+            dataStreaming: new DataStreaming([]),
             mobileModeTest: ()=>false
         });
         const queryDomain = getQueryValue(req, 'domain')[0];
@@ -550,6 +552,7 @@ export const wdgRouter = (services:Services) => (app:Express) => {
             actionUrlCreator: viewUtils.createActionUrl,
             dataReadability: {metadataMapping: {}, commonStructures: {}},
             apiHeadersMapping: services.clientConf.apiHeaders || {},
+            dataStreaming: new DataStreaming([]),
             mobileModeTest: ()=>false
         });
 

--- a/src/js/tiles/core/colloc/index.ts
+++ b/src/js/tiles/core/colloc/index.ts
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { IActionDispatcher, StatelessModel } from 'kombo';
+import { IActionDispatcher } from 'kombo';
 import { List } from 'cnc-tskit';
 import { IAppServices } from '../../../appServices.js';
 import { CorePosAttribute } from '../../../types.js';
@@ -93,7 +93,7 @@ export class CollocationsTile implements ITileProvider {
             waitForTilesTimeoutSecs: waitForTilesTimeoutSecs,
             appServices: appServices,
             service: this.api,
-            concApi: createApiInstance(conf.apiType, conf.apiURL, appServices, apiOptions),
+            concApi: createApiInstance(conf.apiType, conf.apiURL, false, appServices, apiOptions),
             backlink: conf.backlink || null,
             queryType: queryType,
             apiType: conf.apiType,

--- a/src/js/tiles/core/colloc/model.ts
+++ b/src/js/tiles/core/colloc/model.ts
@@ -287,6 +287,7 @@ export class CollocModel extends StatelessModel<CollocModelState> {
             concatMap(([queryId, lemma]) =>
                 callWithExtraVal<{}, ConcResponse, [number, QueryMatch]>(
                     this.concApi,
+                    this.tileId,
                     this.concApi.stateToArgs(
                         {
                             corpname: state.corpname,
@@ -348,6 +349,7 @@ export class CollocModel extends StatelessModel<CollocModelState> {
             concatMap(([queryId,, concId]) => {
                 return callWithExtraVal(
                     this.collApi,
+                    this.tileId,
                     this.collApi.stateToArgs(state, concId),
                     {queryId: queryId}
                 )

--- a/src/js/tiles/core/colloc/service.ts
+++ b/src/js/tiles/core/colloc/service.ts
@@ -66,7 +66,7 @@ export class KontextCollAPI implements DataApi<CollApiArgs, CollApiResponse> {
     }
 
 
-    call(queryArgs:CollApiArgs):Observable<CollApiResponse> {
+    call(tileId:number, queryArgs:CollApiArgs):Observable<CollApiResponse> {
         return ajax$<HttpApiResponse>(
             'GET',
             this.apiURL,

--- a/src/js/tiles/core/concFilter/model.ts
+++ b/src/js/tiles/core/concFilter/model.ts
@@ -331,6 +331,7 @@ export class ConcFilterModel extends StatelessModel<ConcFilterModelState> {
             concatMap(
                 subq => callWithExtraVal(
                     this.api,
+                    this.tileId,
                     this.mkConcArgs(state, subq, concId),
                     subq
                 )

--- a/src/js/tiles/core/concordance/index.ts
+++ b/src/js/tiles/core/concordance/index.ts
@@ -77,7 +77,7 @@ export class ConcordanceTile implements ITileProvider {
     constructor({
         tileId, dispatcher, appServices, ut, queryType, queryMatches,
         widthFract, waitForTiles, waitForTilesTimeoutSecs, conf, domain2,
-        isBusy}:TileFactoryArgs<ConcordanceTileConf>
+        isBusy, useDataStream}:TileFactoryArgs<ConcordanceTileConf>
     ) {
         this.tileId = tileId;
         this.dispatcher = dispatcher;
@@ -87,7 +87,8 @@ export class ConcordanceTile implements ITileProvider {
         const apiOptions = conf.apiType === CoreApiGroup.KONTEXT_API ?
             {authenticateURL: appServices.createActionUrl("/ConcordanceTile/authenticate")} :
             {};
-        const api = createApiInstance(conf.apiType, conf.apiURL, appServices, apiOptions);
+        const api = createApiInstance(
+            conf.apiType, conf.apiURL, useDataStream, appServices, apiOptions);
         this.model = new ConcordanceTileModel({
             dispatcher: dispatcher,
             tileId,

--- a/src/js/tiles/core/concordance/model.ts
+++ b/src/js/tiles/core/concordance/model.ts
@@ -378,7 +378,7 @@ export class ConcordanceTileModel extends StatelessModel<ConcordanceTileState> {
             }
 
         }).pipe(
-            mergeMap(data => callWithExtraVal(this.concApi, data.apiArgs, data.queryIdx)),
+            mergeMap(data => callWithExtraVal(this.concApi, this.tileId, data.apiArgs, data.queryIdx)),
             tap(
                 ([resp, curr]) => {
                     dispatch<typeof Actions.PartialTileDataLoaded>({

--- a/src/js/tiles/core/freqBar/model.ts
+++ b/src/js/tiles/core/freqBar/model.ts
@@ -120,6 +120,7 @@ export class FreqBarModel extends StatelessModel<FreqBarModelState> {
                             }).pipe(
                                 concatMap(critIdx => callWithExtraVal(
                                         this.api,
+                                        this.tileId,
                                         this.api.stateToArgs(
                                             state,
                                             action.payload.concPersistenceIDs[0],

--- a/src/js/tiles/core/freqBar/subqModel.ts
+++ b/src/js/tiles/core/freqBar/subqModel.ts
@@ -170,7 +170,7 @@ export class SubqFreqBarModel extends FreqBarModel {
         critIdx:number
     ):Observable<FreqLoadResult> {
 
-        return this.concApi.call({
+        return this.concApi.call(this.tileId, {
             type: 'concQueryArgs',
             queries: [{
                 corpname: corp,
@@ -212,6 +212,7 @@ export class SubqFreqBarModel extends FreqBarModel {
         .pipe(
             concatMap((v:ConcResponse) => callWithExtraVal(
                 this.api,
+                this.tileId,
                 this.api.stateToArgs(state, v.concPersistenceID, 0), // in subq-mode we accept only a single crit.
                 phrase
             )),

--- a/src/js/tiles/core/freqComparison/index.ts
+++ b/src/js/tiles/core/freqComparison/index.ts
@@ -15,7 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { IActionDispatcher, ViewUtils, StatelessModel } from 'kombo';
+import { IActionDispatcher, ViewUtils } from 'kombo';
 import { Ident, List } from 'cnc-tskit';
 
 import { IAppServices } from '../../../appServices.js';
@@ -92,7 +92,7 @@ export class FreqComparisonTile implements ITileProvider {
             waitForTiles,
             waitForTilesTimeoutSecs,
             appServices,
-            createConcApiInstance(conf.apiType, conf.apiURL, appServices, apiOptions),
+            createConcApiInstance(conf.apiType, conf.apiURL, false, appServices, apiOptions),
             createFreqsApiInstance(conf.apiType, conf.apiURL, appServices, apiOptions),
             conf.backlink || null,
             {

--- a/src/js/tiles/core/freqComparison/model.ts
+++ b/src/js/tiles/core/freqComparison/model.ts
@@ -253,6 +253,7 @@ export class FreqComparisonModel extends StatelessModel<FreqComparisonModelState
             mergeMap(args =>
                 callWithExtraVal(
                     this.concApi,
+                    this.tileId,
                     this.concApi.stateToArgs(
                         {
                             corpname: state.corpname,
@@ -317,6 +318,7 @@ export class FreqComparisonModel extends StatelessModel<FreqComparisonModelState
                 args.concId = resp.concPersistenceID;
                 return callWithExtraVal(
                     this.freqApi,
+                    this.tileId,
                     this.freqApi.stateToArgs(state, resp.concPersistenceID, args.critId),
                     args
                 )

--- a/src/js/tiles/core/freqTree/model.ts
+++ b/src/js/tiles/core/freqTree/model.ts
@@ -227,6 +227,7 @@ export class FreqTreeModel extends StatelessModel<FreqTreeModelState> {
             mergeMap(args =>
                 callWithExtraVal(
                     this.concApi,
+                    this.tileId,
                     this.concApi.stateToArgs(
                         {
                             corpname: state.corpname,
@@ -311,6 +312,7 @@ export class FreqTreeModel extends StatelessModel<FreqTreeModelState> {
                 rxOf(...resp1.fcritValues).pipe(
                     mergeMap(fcritValue =>
                         this.freqTreeApi.call(
+                            this.tileId,
                             stateToAPIArgs(state, args.blockId, 1),
                             resp1.concId,
                             {[resp1.fcrit]: fcritValue}

--- a/src/js/tiles/core/geoAreas/mapLoader.ts
+++ b/src/js/tiles/core/geoAreas/mapLoader.ts
@@ -28,7 +28,7 @@ export class MapLoader implements DataApi<string, string> {
         this.appServices = appServices;
     }
 
-    call(file:string):Observable<string> {
+    call(tileId:number, file:string):Observable<string> {
 
         return ajax$<string>(
             'GET',

--- a/src/js/tiles/core/geoAreas/model.ts
+++ b/src/js/tiles/core/geoAreas/model.ts
@@ -141,10 +141,13 @@ export class GeoAreasModel extends StatelessModel<GeoAreasModelState> {
                                         }
                                     }).pipe(
                                         concatMap(args => this.api.call(
+                                            this.tileId,
                                             this.api.stateToArgs(state, List.head(action.payload.concPersistenceIDs))
                                         ))
                                     ),
-                                    state.mapSVG ? rxOf(null) : this.mapLoader.call('mapCzech.inline.svg')
+                                    state.mapSVG ?
+                                        rxOf(null) :
+                                        this.mapLoader.call(this.tileId, 'mapCzech.inline.svg')
 
                                 ]).subscribe({
                                     next: resp => {

--- a/src/js/tiles/core/html/model.ts
+++ b/src/js/tiles/core/html/model.ts
@@ -92,7 +92,7 @@ export class HtmlModel extends StatelessModel<HtmlModelState> {
 
     private requestData(state:HtmlModelState, variant:string, seDispatch:SEDispatcher):void {
         (variant ?
-            this.service.call(this.service.stateToArgs(state, variant)) :
+            this.service.call(this.tileId, this.service.stateToArgs(state, variant)) :
             rxOf(null)
 
         ).pipe(

--- a/src/js/tiles/core/matchingDocs/model.ts
+++ b/src/js/tiles/core/matchingDocs/model.ts
@@ -194,7 +194,7 @@ export class MatchingDocsModel extends StatelessModel<MatchingDocsModelState> {
                             }
 
                         }).pipe(
-                            concatMap(_ => this.api.call(this.api.stateToArgs(
+                            concatMap(_ => this.api.call(this.tileId, this.api.stateToArgs(
                                 state, List.head(action.payload.concPersistenceIDs))))
 
                         ).subscribe(
@@ -232,9 +232,9 @@ export class MatchingDocsModel extends StatelessModel<MatchingDocsModelState> {
 
         } else {
             const variant = findCurrQueryMatch(this.queryMatches[0]);
-            this.api.call(this.api.stateToArgs(state, variant.word))
-            .subscribe(
-                (resp) => {
+            this.api.call(this.tileId, this.api.stateToArgs(state, variant.word))
+            .subscribe({
+                next: (resp) => {
                     dispatch<typeof Actions.TileDataLoaded>({
                         name: Actions.TileDataLoaded.name,
                         payload: {
@@ -245,7 +245,7 @@ export class MatchingDocsModel extends StatelessModel<MatchingDocsModelState> {
                         }
                     });
                 },
-                error => {
+                error: error => {
                     dispatch<typeof Actions.TileDataLoaded>({
                         name: Actions.TileDataLoaded.name,
                         payload: {
@@ -257,7 +257,7 @@ export class MatchingDocsModel extends StatelessModel<MatchingDocsModelState> {
                         error: error
                     });
                 }
-            );
+            });
         }
     }
 }

--- a/src/js/tiles/core/mergeCorpFreq/index.ts
+++ b/src/js/tiles/core/mergeCorpFreq/index.ts
@@ -122,7 +122,7 @@ export class MergeCorpFreqTile implements ITileProvider {
             waitForTilesTimeoutSecs,
             appServices,
             concApi: conf.apiType === CoreApiGroup.MQUERY ? null :
-                     createConcApiInstance(conf.apiType, conf.apiURL, appServices, apiOptions),
+                     createConcApiInstance(conf.apiType, conf.apiURL, false, appServices, apiOptions),
             freqApi: createFreqApiInstance(conf.apiType, conf.apiURL, appServices, apiOptions),
             initState: {
                 isBusy: isBusy,

--- a/src/js/tiles/core/mergeCorpFreq/model.ts
+++ b/src/js/tiles/core/mergeCorpFreq/model.ts
@@ -292,6 +292,7 @@ export class MergeCorpFreqModel extends StatelessModel<MergeCorpFreqModelState> 
             concatMap(([queryId, args, lemma]) =>
                 callWithExtraVal(
                     this.concApi,
+                    this.tileId,
                     this.concApi.stateToArgs(
                         {
                             corpname: args.corpname,
@@ -334,6 +335,7 @@ export class MergeCorpFreqModel extends StatelessModel<MergeCorpFreqModelState> 
                 };
                 return callWithExtraVal(
                     this.freqApi,
+                    this.tileId,
                     this.freqApi.stateToArgs(sourceArgs, concId),
                     auxArgs
                 );

--- a/src/js/tiles/core/multiWordGeoAreas/index.ts
+++ b/src/js/tiles/core/multiWordGeoAreas/index.ts
@@ -84,7 +84,7 @@ export class MultiWordGeoAreasTile implements ITileProvider {
             waitForTilesTimeoutSecs,
             appServices,
             queryMatches,
-            concApi: createConcApiInstance(conf.apiType, conf.apiURL, appServices, apiOptions),
+            concApi: createConcApiInstance(conf.apiType, conf.apiURL, false, appServices, apiOptions),
             freqApi: createFreqApiInstance(conf.apiType, conf.apiURL, appServices, apiOptions),
             mapLoader: new MapLoader(appServices),
             initState: {

--- a/src/js/tiles/core/multiWordGeoAreas/mapLoader.ts
+++ b/src/js/tiles/core/multiWordGeoAreas/mapLoader.ts
@@ -28,7 +28,7 @@ export class MapLoader implements DataApi<string, string> {
         this.appServices = appServices;
     }
 
-    call(file:string):Observable<string> {
+    call(tileId:number, file:string):Observable<string> {
 
         return ajax$<string>(
             'GET',

--- a/src/js/tiles/core/multiWordGeoAreas/model.ts
+++ b/src/js/tiles/core/multiWordGeoAreas/model.ts
@@ -145,7 +145,7 @@ export class MultiWordGeoAreasModel extends StatelessModel<MultiWordGeoAreasMode
                         (action, syncData) => {
                             if (ConcActions.isTileDataLoaded(action) && action.payload.tileId === this.waitForTile) {
                                 const dataStream = zip(
-                                    this.mapLoader.call('mapCzech.inline.svg').pipe(
+                                    this.mapLoader.call(this.tileId, 'mapCzech.inline.svg').pipe(
                                         repeat(action.payload.concPersistenceIDs.length)),
                                     rxOf(...List.map(
                                         (concId, queryId) => tuple(queryId, concId),
@@ -154,6 +154,7 @@ export class MultiWordGeoAreasModel extends StatelessModel<MultiWordGeoAreasMode
                                     .pipe(
                                         concatMap(([queryId, concId]) => callWithExtraVal(
                                             this.freqApi,
+                                            this.tileId,
                                             this.freqApi.stateToArgs(state, concId),
                                             {
                                                 concId: concId,
@@ -298,11 +299,12 @@ export class MultiWordGeoAreasModel extends StatelessModel<MultiWordGeoAreasMode
 
     private getConcordances(state:MultiWordGeoAreasModelState) {
         return zip(
-            this.mapLoader.call('mapCzech.inline.svg').pipe(repeat(state.currQueryMatches.length)),
+            this.mapLoader.call(this.tileId, 'mapCzech.inline.svg').pipe(repeat(state.currQueryMatches.length)),
             rxOf(...state.currQueryMatches.map((lemma, queryId) => [queryId, lemma] as [number, QueryMatch])[Symbol.iterator]()).pipe(
                 concatMap(([queryId, lemmaVariant]) =>
                     callWithExtraVal(
                         this.concApi,
+                        this.tileId,
                         this.concApi.stateToArgs(
                             {
                                 corpname: state.corpname,
@@ -339,6 +341,7 @@ export class MultiWordGeoAreasModel extends StatelessModel<MultiWordGeoAreasMode
                     args.concId = resp.concPersistenceID;
                     return callWithExtraVal(
                         this.freqApi,
+                        this.tileId,
                         this.freqApi.stateToArgs(state, args.concId),
                         args
                     )

--- a/src/js/tiles/core/multiWordTimeDistrib/index.ts
+++ b/src/js/tiles/core/multiWordTimeDistrib/index.ts
@@ -88,6 +88,7 @@ export class MultiWordTimeDistTile implements ITileProvider {
                         createConcApiInstance(
                             conf.apiType,
                             url,
+                            false,
                             appServices,
                             apiOptions,
                         ),

--- a/src/js/tiles/core/multiWordTimeDistrib/model.ts
+++ b/src/js/tiles/core/multiWordTimeDistrib/model.ts
@@ -429,6 +429,7 @@ export class MultiWordTimeDistribModel extends StatelessModel<MultiWordTimeDistr
                     const [concApi, freqApi] = this.apiFactory.getRandomValue();
                     return callWithExtraVal(
                         concApi,
+                        this.tileId,
                         concApi.stateToArgs(
                             {
                                 corpname: state.corpname,
@@ -502,6 +503,7 @@ export class MultiWordTimeDistribModel extends StatelessModel<MultiWordTimeDistr
                     if (args.concId) {
                         return callWithExtraVal(
                             args.freqApi,
+                            this.tileId,
                             {
                                 corpName: state.corpname,
                                 subcorpName: args.subcName,

--- a/src/js/tiles/core/speeches/model.ts
+++ b/src/js/tiles/core/speeches/model.ts
@@ -431,9 +431,12 @@ export class SpeechesModel extends StatelessModel<SpeechesModelState> {
 
     private reloadData({state, dispatch, tokens, concId, expand, kwicNumTokens}:ReloadDataArgs):void {
         this.api
-            .call(this.createArgs(state, (tokens || state.availTokens)[state.tokenIdx], kwicNumTokens, expand))
-            .subscribe(
-                (payload) => {
+            .call(
+                this.tileId,
+                this.createArgs(state, (tokens || state.availTokens)[state.tokenIdx], kwicNumTokens, expand)
+
+            ).subscribe({
+                next: (payload) => {
                     dispatch<typeof Actions.TileDataLoaded>({
                         name: Actions.TileDataLoaded.name,
                         payload: {
@@ -465,7 +468,7 @@ export class SpeechesModel extends StatelessModel<SpeechesModelState> {
                         }
                     });
                 },
-                (error) => {
+                error: (error) => {
                     console.error(error);
                     dispatch<typeof Actions.TileDataLoaded>({
                         name: Actions.TileDataLoaded.name,
@@ -482,7 +485,7 @@ export class SpeechesModel extends StatelessModel<SpeechesModelState> {
                         }
                     });
                 }
-            );
+            });
     }
 
     private createBackLink(state:SpeechesModelState):BacklinkWithArgs<BacklinkArgs> {

--- a/src/js/tiles/core/syD/api.ts
+++ b/src/js/tiles/core/syD/api.ts
@@ -82,7 +82,7 @@ export class SyDAPI implements DataApi<RequestArgs, Response> {
         this.freqApi = freqApi;
     }
 
-    call(args:RequestArgs):Observable<Response> {
+    call(tileId:number, args:RequestArgs):Observable<Response> {
         const t1 = new Date().getTime();
 
         // query 1, corp 1 ---------
@@ -128,6 +128,7 @@ export class SyDAPI implements DataApi<RequestArgs, Response> {
         };
         const concQ1C1$ = callWithExtraVal(
             this.concApi,
+            tileId,
             {...args1, kwicleftctx: -5, kwicrightctx: 5},
             `${args.corp1}/${args.word1}`
         ).pipe(share());
@@ -175,6 +176,7 @@ export class SyDAPI implements DataApi<RequestArgs, Response> {
         };
         const concQ1C2$ = callWithExtraVal(
             this.concApi,
+            tileId,
             {...args2, kwicleftctx: -5, kwicrightctx: 5},
             `${args.corp2}/${args.word1}`
         ).pipe(share());
@@ -222,6 +224,7 @@ export class SyDAPI implements DataApi<RequestArgs, Response> {
         };
         const concQ2C1$ = callWithExtraVal(
             this.concApi,
+            tileId,
             {...args3, kwicleftctx: -5, kwicrightctx: 5},
             `${args.corp1}/${args.word2}`
         ).pipe(share());
@@ -269,6 +272,7 @@ export class SyDAPI implements DataApi<RequestArgs, Response> {
         };
         const concQ2C2$ = callWithExtraVal(
             this.concApi,
+            tileId,
             {...args4, kwicleftctx: -5, kwicrightctx: 5},
             `${args.corp2}/${args.word2}`
         ).pipe(share());
@@ -290,7 +294,7 @@ export class SyDAPI implements DataApi<RequestArgs, Response> {
                                 format: args.format,
                             } as SingleCritQueryArgs;
 
-                            return this.freqApi.call(args1).pipe(
+                            return this.freqApi.call(tileId, args1).pipe(
                                 concatMap(
                                     (resp) => rxOf({
                                         conc_persistence_op_id: resp.conc_persistence_op_id,

--- a/src/js/tiles/core/syD/model.ts
+++ b/src/js/tiles/core/syD/model.ts
@@ -85,13 +85,13 @@ export class SydModel extends StatelessModel<SydModelState> {
                 state.result = [];
             },
             (state, action, dispatch) => {
-                this.api.call(stateToArgs(
+                this.api.call(this.tileId, stateToArgs(
                     state,
                     this.queryMatches[0][0].word, // TODO !!!
                     pipe(this.queryMatches, List.slice(1), List.map(lvList => lvList[0].word)) // TODO
                 ))
-                .subscribe(
-                    (data) => {
+                .subscribe({
+                    next: (data) => {
                         dispatch<typeof Actions.TileDataLoaded>({
                             name: Actions.TileDataLoaded.name,
                             payload: {
@@ -101,7 +101,7 @@ export class SydModel extends StatelessModel<SydModelState> {
                             }
                         });
                     },
-                    (error) => {
+                    error: (error) => {
                         dispatch<typeof Actions.TileDataLoaded>({
                             name: Actions.TileDataLoaded.name,
                             error,
@@ -112,7 +112,7 @@ export class SydModel extends StatelessModel<SydModelState> {
                             }
                         });
                     }
-                );
+                });
             }
         );
 

--- a/src/js/tiles/core/syntacticColls/model.ts
+++ b/src/js/tiles/core/syntacticColls/model.ts
@@ -108,7 +108,7 @@ export class SyntacticCollsModel extends StatelessModel<SyntacticCollsModelState
             },
             (state, action, seDispatch) => {
                 merge(...List.map(qType =>
-                    this.api.call(this.api.stateToArgs(state, qType)),
+                    this.api.call(this.tileId, this.api.stateToArgs(state, qType)),
                     state.displayTypes,
                 )).subscribe({
                     next: ([qType, data]) => {
@@ -169,7 +169,7 @@ export class SyntacticCollsModel extends StatelessModel<SyntacticCollsModelState
                 const q = state.data[action.payload.qType].examplesQueryTpl.replace('%s', action.payload.word);
                 (Dict.hasKey(q, state.examplesCache) ?
                     rxOf(state.examplesCache[q]) :
-                    this.eApi.call(this.eApi.stateToArgs(state, q)).pipe(
+                    this.eApi.call(this.tileId, this.eApi.stateToArgs(state, q)).pipe(
                         map(
                             data => ({
                                 ...data,

--- a/src/js/tiles/core/timeDistrib/index.ts
+++ b/src/js/tiles/core/timeDistrib/index.ts
@@ -89,6 +89,7 @@ export class TimeDistTile implements ITileProvider {
                         createConcApiInstance(
                             conf.apiType,
                             url,
+                            false,
                             appServices,
                             apiOptions,
                         ),

--- a/src/js/tiles/core/timeDistrib/model.ts
+++ b/src/js/tiles/core/timeDistrib/model.ts
@@ -285,6 +285,7 @@ export class TimeDistribModel extends StatelessModel<TimeDistribModelState> {
                     dispatch,
                     SubchartID.SECONDARY,
                     this.appServices.queryLemmaDbApi(
+                        this.tileId,
                         this.queryDomain,
                         state.wordCmp,
                         state.mainPosAttr
@@ -485,6 +486,7 @@ export class TimeDistribModel extends StatelessModel<TimeDistribModelState> {
                     const [concApi, freqApi] = this.apiFactory.getRandomValue();
                     return callWithExtraVal(
                         concApi,
+                        this.tileId,
                         concApi.stateToArgs(
                             {
                                 corpname: state.corpname,
@@ -571,6 +573,7 @@ export class TimeDistribModel extends StatelessModel<TimeDistribModelState> {
                 ),
                 concatMap(args => callWithExtraVal(
                     args.freqApi,
+                    this.tileId,
                     {
                         corpName: args.corpName,
                         subcorpName: args.subcName,
@@ -650,6 +653,7 @@ export class TimeDistribModel extends StatelessModel<TimeDistribModelState> {
                         if (args.concId) {
                             return callWithExtraVal(
                                 args.freqApi,
+                                this.tileId,
                                 {
                                     corpName: state.corpname,
                                     subcorpName: args.subcName,
@@ -661,6 +665,7 @@ export class TimeDistribModel extends StatelessModel<TimeDistribModelState> {
                         } else if (concResp.query) {
                             return callWithExtraVal(
                                 args.freqApi,
+                                this.tileId,
                                 {
                                     corpName: state.corpname,
                                     subcorpName: args.subcName,

--- a/src/js/tiles/core/translations/model.ts
+++ b/src/js/tiles/core/translations/model.ts
@@ -169,7 +169,7 @@ export class TranslationsModel extends StatelessModel<GeneralTranslationsModelSt
 
     private loadData(state:GeneralTranslationsModelState, dispatch:SEDispatcher):void {
         const srchLemma = findCurrQueryMatch(this.queryMatches[0]);
-        this.api.call(this.api.stateToArgs(state, srchLemma.lemma))
+        this.api.call(this.tileId, this.api.stateToArgs(state, srchLemma.lemma))
             .pipe(
                 map(item => {
                     const colors = this.scaleColorGen(0)

--- a/src/js/tiles/core/treqSubsets/model.ts
+++ b/src/js/tiles/core/treqSubsets/model.ts
@@ -149,6 +149,7 @@ export class TreqSubsetModel extends StatelessModel<TranslationsSubsetsModelStat
                     mergeMap(subset =>
                         callWithExtraVal(
                             this.api,
+                            this.tileId,
                             this.api.stateToArgs(
                                 state,
                                 srchLemma.lemma,

--- a/src/js/tiles/core/wordForms/model.ts
+++ b/src/js/tiles/core/wordForms/model.ts
@@ -270,7 +270,7 @@ export class WordFormsModel extends StatelessModel<WordFormsModelState> {
     }
 
     private fetchWordForms(args:RequestArgs|RequestConcArgs, dispatch:SEDispatcher):void {
-        this.api.call(args).pipe(
+        this.api.call(this.tileId, args).pipe(
             map((v => {
                 const updated = Maths.calcPercentRatios(
                     (item) => item.freq,

--- a/src/js/tiles/core/wordFreq/model.ts
+++ b/src/js/tiles/core/wordFreq/model.ts
@@ -178,8 +178,7 @@ export class SummaryModel extends StatelessModel<SummaryModelState> {
             null,
             (state, action, dispatch) => {
                 if (action.payload.tileId === this.tileId) {
-                    this.sourceInfoApi.call({
-                        tileId: this.tileId,
+                    this.sourceInfoApi.call(this.tileId, {
                         queryType,
                         domain: this.queryDomain,
                         corpname: state.corpname,
@@ -221,7 +220,7 @@ export class SummaryModel extends StatelessModel<SummaryModelState> {
         }).pipe(
             concatMap(
                 (args) => testIsDictMatch(args.variant) ?
-                    this.api.call({
+                    this.api.call(this.tileId, {
                         domain: args.lang,
                         word: args.variant.word,
                         lemma: args.variant.lemma,

--- a/src/js/tiles/core/wordSim/model.ts
+++ b/src/js/tiles/core/wordSim/model.ts
@@ -179,13 +179,14 @@ export class WordSimModel extends StatelessModel<WordSimModelState> {
             mergeMap(([queryId, queryMatch]) => queryMatch.abs >= state.minMatchFreq ?
                 callWithExtraVal(
                     this.api,
+                    this.tileId,
                     this.api.stateToArgs(state, queryMatch),
                     queryId
                 ) :
                 rxOf(tuple({words: [] as Array<WordSimWord>}, queryId))
             )
-        ).subscribe(
-            ([data, queryId]) => {
+        ).subscribe({
+            next: ([data, queryId]) => {
                 seDispatch<typeof Actions.TileDataLoaded>({
                     name: Actions.TileDataLoaded.name,
                     payload: {
@@ -209,7 +210,7 @@ export class WordSimModel extends StatelessModel<WordSimModelState> {
                 });
 
             },
-            (error) => {
+            error: (error) => {
                 seDispatch<typeof Actions.TileDataLoaded>({
                     name: Actions.TileDataLoaded.name,
                     payload: {
@@ -224,7 +225,7 @@ export class WordSimModel extends StatelessModel<WordSimModelState> {
                     error
                 })
             }
-        );
+        });
     }
 
 }

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -46,7 +46,7 @@ export enum CorePosAttribute {
  */
 export interface DataApi<T, U> {
 
-    call(queryArgs:T):Observable<U>;
+    call(tileId:number, queryArgs:T):Observable<U>;
 }
 
 /**


### PR DESCRIPTION
Note that individual API clients must explicitly use the DataStreaming.registerTileRequest() method instead of ajax$() to be able to push their request to the common wstream request and also read data from the response stream.

Currently, only concordance for KonText contains this update.