### PR TITLE
Add support for data streaming to TimeDist tile

### DIFF
--- a/src/js/api/factory/timeDistrib.ts
+++ b/src/js/api/factory/timeDistrib.ts
@@ -26,6 +26,7 @@ import { MQueryTimeDistribStreamApi } from '../vendor/mquery/timeDistrib.js';
 export function createApiInstance(
 	apiIdent:string,
 	apiURL:string,
+	useDataStream:boolean,
 	apiServices:IApiServices,
 	conf:CustomArgs,
 	apiOptions:{}
@@ -53,6 +54,7 @@ export function createApiInstance(
 		case CoreApiGroup.MQUERY:
 			return new MQueryTimeDistribStreamApi(
 				apiURL,
+				useDataStream,
 				apiServices,
                 conf
 			);

--- a/src/js/page/streaming.ts
+++ b/src/js/page/streaming.ts
@@ -28,7 +28,12 @@ interface TileRequest {
     method:HTTP.Method,
     body:unknown;
     contentType:string;
-    base64EncodeResult:boolean;
+    base64EncodeResult?:boolean;
+
+    // Specifies whether the backend itself provides
+    // EventSource stream. In such case, we must integrate
+    // this stream into the main one.
+    isEventSource?:boolean;
 }
 
 interface EventItem<T = unknown> {

--- a/src/js/tiles/core/multiWordTimeDistrib/index.ts
+++ b/src/js/tiles/core/multiWordTimeDistrib/index.ts
@@ -66,7 +66,7 @@ export class MultiWordTimeDistTile implements ITileProvider {
 
     constructor({
         dispatcher, tileId, waitForTiles, waitForTilesTimeoutSecs, ut, theme, appServices,
-        widthFract, queryMatches, domain1, conf, isBusy
+        widthFract, queryMatches, domain1, conf, isBusy, useDataStream
     }:TileFactoryArgs<TimeDistTileConf>) {
 
         this.dispatcher = dispatcher;
@@ -95,6 +95,7 @@ export class MultiWordTimeDistTile implements ITileProvider {
                         createFreqApiInstance(
                             conf.apiType,
                             url,
+                            useDataStream,
                             appServices,
                             {
                                 ...conf.customApiArgs,

--- a/src/js/tiles/core/timeDistrib/index.ts
+++ b/src/js/tiles/core/timeDistrib/index.ts
@@ -65,7 +65,7 @@ export class TimeDistTile implements ITileProvider {
 
     constructor({
         dispatcher, tileId, waitForTiles, waitForTilesTimeoutSecs, ut, theme, appServices,
-        widthFract, queryMatches, domain1, conf, isBusy, mainPosAttr
+        widthFract, queryMatches, domain1, conf, isBusy, mainPosAttr, useDataStream
     }:TileFactoryArgs<TimeDistTileConf>) {
 
         this.dispatcher = dispatcher;
@@ -96,6 +96,7 @@ export class TimeDistTile implements ITileProvider {
                         createFreqApiInstance(
                             conf.apiType,
                             url,
+                            useDataStream,
                             appServices,
                             conf.customApiArgs,
                             apiOptions,


### PR DESCRIPTION
The tile supported the technology even before this, but the current change means that it can be integrated into the main data stream of WaG