### PR TITLE
Especially for stateful models, introduce special api calling methods:

### DIFF
--- a/src/js/page/index.ts
+++ b/src/js/page/index.ts
@@ -37,7 +37,9 @@ import { Client, tuple, List, pipe, Dict } from 'cnc-tskit';
 import { WdglanceMainProps } from '../views/main.js';
 import { LayoutManager, TileGroup } from './layout.js';
 import { TileConf } from './tile.js';
-import { DataStreaming } from './streaming.js';
+import { DataStreaming, IDataStreaming } from './streaming.js';
+import { callWithExtraVal } from '../api/util.js';
+import { DataApi } from '../types.js';
 
 
 interface MountArgs {
@@ -170,6 +172,17 @@ export function initClient(
         actionUrlCreator: viewUtils.createActionUrl,
         dataReadability: config.dataReadability || {metadataMapping: {}, commonStructures: {}},
         apiHeadersMapping: config.apiHeaders,
+        apiCaller: {
+            callAPI: (api, streaming, tileId, queryIdx, queryArgs) => api.call(streaming, tileId, queryIdx, queryArgs),
+            callAPIWithExtraVal: <T, U, V>(
+                api:DataApi<T, U>,
+                streaming:IDataStreaming,
+                tileId:number,
+                queryIdx:number,
+                args:T,
+                passThrough:V
+            ) => callWithExtraVal(streaming, api, tileId, queryIdx, args, passThrough)
+        },
         dataStreaming,
         mobileModeTest: () => Client.isMobileTouchDevice()
     });

--- a/src/js/server/routes/common.ts
+++ b/src/js/server/routes/common.ts
@@ -35,6 +35,8 @@ import { ErrPageProps } from '../../views/error.js';
 import { TileGroup } from '../../page/layout.js';
 import { DataStreaming } from '../../page/streaming.js';
 import { ServerNotifications } from '../../page/notifications.js';
+import { DataApi } from '../../types.js';
+import { EMPTY, Observable } from 'rxjs';
 
 /**
  * Obtain value (or values if a key is provided multiple times) from
@@ -141,6 +143,10 @@ export function createHelperServices(services:Services, uiLang:string):[ViewUtil
         viewUtils,
         new AppServices({
             notifications: new ServerNotifications(),
+            apiCaller: {
+                callAPI: (api, streaming, tileId, queryIdx, queryArgs) => EMPTY,
+                callAPIWithExtraVal: (api, streaming, tileId, queryIdx, queryArgs, passThrough) => EMPTY
+            },
             uiLang: uiLang,
             translator: viewUtils,
             staticUrlCreator: viewUtils.createStaticUrl,

--- a/src/js/server/routes/index.ts
+++ b/src/js/server/routes/index.ts
@@ -17,7 +17,7 @@
  */
 import { Express, Request, Response } from 'express';
 import { ViewUtils } from 'kombo';
-import { Observable, of as rxOf } from 'rxjs';
+import { EMPTY, Observable, of as rxOf } from 'rxjs';
 import { concatMap, map, reduce, tap } from 'rxjs/operators';
 import { HTTP, List, pipe, Dict, tuple } from 'cnc-tskit';
 
@@ -431,6 +431,10 @@ export const wdgRouter = (services:Services) => (app:Express) => {
             actionUrlCreator: viewUtils.createActionUrl,
             dataReadability: {metadataMapping: {}, commonStructures: {}},
             apiHeadersMapping: services.clientConf.apiHeaders || {},
+            apiCaller: {
+                callAPI: (api, streaming, tileId, queryIdx, queryArgs) => EMPTY,
+                callAPIWithExtraVal: (api, streaming, tileId, queryIdx, queryArgs, passThrough) => EMPTY
+            },
             dataStreaming: new DataStreaming(null, [], null, 1000, null),
             mobileModeTest: ()=>false
         });

--- a/src/js/tiles/core/concordance/model.ts
+++ b/src/js/tiles/core/concordance/model.ts
@@ -565,7 +565,7 @@ export class ConcordanceTileModel extends StatefulModel<ConcordanceTileState> {
 
         }).pipe(
             mergeMap(
-                ([args, queryIdx]) => this.concApi.call(streaming, this.tileId, queryIdx, args)
+                ([args, queryIdx]) => this.appServices.callAPI(this.concApi, streaming, this.tileId, queryIdx, args)
             )
         )
     }

--- a/src/js/tiles/core/freqBar/model.ts
+++ b/src/js/tiles/core/freqBar/model.ts
@@ -159,9 +159,9 @@ export class FreqBarModel extends StatefulModel<FreqBarModelState> {
 
                 }).pipe(
                     mergeMap(([args, pass]) =>
-                        callWithExtraVal(
-                            this.appServices.dataStreaming(),
+                        appServices.callAPIWithExtraVal(
                             this.api,
+                            this.appServices.dataStreaming(),
                             this.tileId,
                             pass.queryIdx,
                             args,


### PR DESCRIPTION
The reason is that while StatelesModel can be easily triggered by RequestQueryResponse action on the server as it never triggers its separate "side effect" (which calls ajax  etc.), in case of the StatefulModel, we have no such control. It means that once the server trigger the RequestQueryResponse action (so the models set their initial values properly for the search page), Stateful models start to fetch data via their api adapters which is not what we want. So currently, we inject special methods for calling api into AppServices and on the server, their immediately end any observable. But this cannot be forced, so it is up to a developer not to forget this...