### PR TITLE
Fix problem in preview query mode where cmp+single supporting tiles ...

### DIFF
--- a/src/js/app.ts
+++ b/src/js/app.ts
@@ -178,7 +178,7 @@ export function createRootComponent({
         config.tiles,
         Dict.forEach(
             (tileConf, tileId) => {
-                const tile = factory(tileId, tileConf);
+                const tile = factory.create(tileId, tileConf);
                 attachTile({
                     data: tiles,
                     tileName: tileId,

--- a/src/js/page/tileLoader.ts
+++ b/src/js/page/tileLoader.ts
@@ -69,44 +69,65 @@ export const mkTileFactory = (
     theme:Theme,
     layoutManager:LayoutManager,
     queryType:QueryType,
-    translatLanguage:string) => (
-            confName:string,
-            conf:TileConf):ITileProvider|null => {
-        if (conf.isDisabled || !layoutManager.isInCurrentLayout(layoutManager.getTileNumber(confName))) {
-            return new EmptyTile(layoutManager.getTileNumber(confName));
+    translatLanguage:string
 
-        } else {
-            const tileFactory = tileFactories[conf.tileType];
-            if (typeof tileFactory === 'undefined') {
-                throw new Error(`Cannot invoke tile init() for ${confName} - type ${conf.tileType} not found. Check your src/js/tiles/custom directory.`);
+) => {
 
-            } else if (typeof tileFactory.create !== 'function' || typeof tileFactory.sanityCheck !== 'function') {
-                throw new Error(`Cannot invoke tile init() for ${confName} (type ${conf.tileType}). Expected type [function], got [${typeof tileFactory}].`);
+    const factoryObj = {
+
+        createdTiles: {},
+
+        create(confName:string, conf:TileConf):ITileProvider|null  {
+            if (conf.isDisabled || !layoutManager.isInCurrentLayout(layoutManager.getTileNumber(confName))) {
+                return new EmptyTile(layoutManager.getTileNumber(confName));
+
+            } else {
+                const tileFactory = tileFactories[conf.tileType];
+                if (typeof tileFactory === 'undefined') {
+                    throw new Error(`Cannot invoke tile init() for ${confName} - type ${conf.tileType} not found. Check your src/js/tiles/custom directory.`);
+
+                } else if (typeof tileFactory.create !== 'function' || typeof tileFactory.sanityCheck !== 'function') {
+                    throw new Error(`Cannot invoke tile init() for ${confName} (type ${conf.tileType}). Expected type [function], got [${typeof tileFactory}].`);
+                }
+
+                const tileId = layoutManager.getTileNumber(confName);
+                const tileLayoutConf = layoutManager.getLayoutTileConf(tileId);
+
+                // In the 'preview' mode, we need to make sure tiles supporting both 'single' and 'cmp' modes
+                // get both single and cmp queries. For this matter we store information about each tile type
+                // instantiation where for the first instance, we give the tile just a single word search while
+                // for the second (and more) we provide multiple queries. This all applies just for the
+                // preview mode and it is made to align with hardcoded layout of the preview result page.
+                const queryMatchesAppl = queryType === QueryType.PREVIEW && !factoryObj.createdTiles.hasOwnProperty(conf.tileType) ?
+                        [queryMatches[0]] : queryMatches;
+                const args:TileFactoryArgs<{}> = {
+                    tileId,
+                    dispatcher,
+                    ut: viewUtils,
+                    queryMatches: queryMatchesAppl,
+                    appServices,
+                    queryType,
+                    translatLanguage,
+                    readDataFromTile: layoutManager.getTileNumber(tileLayoutConf.readDataFrom),
+                    widthFract: tileLayoutConf.width,
+                    theme,
+                    conf,
+                    isBusy: true,
+                    mainPosAttr: layoutManager.getLayoutMainPosAttr(),
+                    useDataStream: !!conf.useDataStream,
+                    dependentTiles: layoutManager.getDependentTiles(tileId)
+                };
+                const errs = tileFactory.sanityCheck(args);
+                if (!List.empty(errs)) {
+                    throw new Error('Tile sanity check: ' + List.head(errs).message); // TODO maybe we should join the errors?
+                }
+                factoryObj.createdTiles[conf.tileType] = factoryObj.createdTiles[conf.tileType] ?
+                    factoryObj.createdTiles[conf.tileType] + 1 :
+                    1;
+                return tileFactory.create(args);
             }
-
-            const tileId = layoutManager.getTileNumber(confName);
-            const tileLayoutConf = layoutManager.getLayoutTileConf(tileId);
-            const args:TileFactoryArgs<{}> = {
-                tileId,
-                dispatcher,
-                ut: viewUtils,
-                queryMatches,
-                appServices,
-                queryType,
-                translatLanguage,
-                readDataFromTile: layoutManager.getTileNumber(tileLayoutConf.readDataFrom),
-                widthFract: tileLayoutConf.width,
-                theme,
-                conf,
-                isBusy: true,
-                mainPosAttr: layoutManager.getLayoutMainPosAttr(),
-                useDataStream: !!conf.useDataStream,
-                dependentTiles: layoutManager.getDependentTiles(tileId)
-            };
-            const errs = tileFactory.sanityCheck(args);
-            if (!List.empty(errs)) {
-                throw new Error('Tile sanity check: ' + List.head(errs).message); // TODO maybe we should join the errors?
-            }
-            return tileFactory.create(args);
         }
-};
+    }
+
+    return factoryObj;
+}

--- a/src/js/server/routes/main.ts
+++ b/src/js/server/routes/main.ts
@@ -49,7 +49,7 @@ import { attachNumericTileIdents } from '../../page/index.js';
 import { createInstance, FreqDBType } from '../freqdb/factory.js';
 import urlJoin from 'url-join';
 import { TileConf } from '../../page/tile.js';
-import { layoutConf, queriesConf, tileConf } from '../../conf/preview.js';
+import { layoutConf, queriesConf, generatePreviewTileConf } from '../../conf/preview.js';
 
 
 interface MkRuntimeClientConfArgs {
@@ -365,7 +365,7 @@ export function queryAction({
     next
 }:QueryActionArgs) {
     if (queryType === QueryType.PREVIEW) {
-        services.clientConf.tiles = tileConf;
+        services.clientConf.tiles = generatePreviewTileConf();
         services.clientConf.layouts = layoutConf;
     }
 

--- a/src/js/tiles/core/geoAreas/index.ts
+++ b/src/js/tiles/core/geoAreas/index.ts
@@ -106,9 +106,9 @@ export class GeoAreasTile implements ITileProvider {
             },
         });
         this.label = appServices.importExternalMessage(conf.label || 'geolocations__main_label');
-        this.view = queryType === QueryType.SINGLE_QUERY ?
-            singleViewInit(this.dispatcher, ut, theme, this.model) :
-            compareViewInit(this.dispatcher, ut, theme, this.model);
+        this.view = queryType === QueryType.CMP_QUERY || queryType === QueryType.PREVIEW && queryMatches.length > 1 ?
+            compareViewInit(this.dispatcher, ut, theme, this.model) :
+            singleViewInit(this.dispatcher, ut, theme, this.model);
     }
 
     getLabel():string {

--- a/src/js/tiles/core/timeDistrib/index.ts
+++ b/src/js/tiles/core/timeDistrib/index.ts
@@ -104,7 +104,7 @@ export class TimeDistTile implements ITileProvider {
             queryMatches,
         });
         this.label = appServices.importExternalMessage(conf.label || 'timeDistrib__main_label');
-        this.view = queryType === QueryType.CMP_QUERY ?
+        this.view = queryType === QueryType.CMP_QUERY || queryType === QueryType.PREVIEW && queryMatches.length > 1 ?
             compareViewInit(this.dispatcher, ut, theme, this.model) :
             singleViewInit(this.dispatcher, ut, theme, this.model);
     }

--- a/src/js/tiles/core/wordFreq/index.ts
+++ b/src/js/tiles/core/wordFreq/index.ts
@@ -17,8 +17,11 @@
  */
 import { IAppServices } from '../../../appServices.js';
 import { QueryType } from '../../../query/index.js';
-import { AltViewIconProps, DEFAULT_ALT_VIEW_ICON, ITileProvider, ITileReloader, TileComponent, TileConf, TileFactory, TileFactoryArgs } from '../../../page/tile.js';
-import { FlevelDistribItem, SummaryModel, findCurrentMatches, mkEmptySimilarWords } from './model.js';
+import {
+    AltViewIconProps, DEFAULT_ALT_VIEW_ICON, ITileProvider, ITileReloader, TileComponent, TileConf,
+    TileFactory, TileFactoryArgs } from '../../../page/tile.js';
+import {
+    FlevelDistribItem, SummaryModel, findCurrentMatches, mkEmptySimilarWords } from './model.js';
 import { init as viewInit } from './views/index.js';
 import { SimilarFreqWordsFrodoAPI } from './similarFreq.js';
 import { CorpusInfoAPI } from '../../../api/vendor/mquery/corpusInfo.js';
@@ -154,8 +157,6 @@ export class WordFreqTile implements ITileProvider {
 }
 
 export const init:TileFactory<WordFreqTileConf> = {
-
     sanityCheck: (args) => [],
-
     create: (args) => new WordFreqTile(args)
 };


### PR DESCRIPTION
... where always switched to the 'cmp' mode. The new approach with modified tile factory creates two distinct versions of each such file with modified queryMatches.