### PR TITLE
Fix preview mode and generalize geoAreas:

### DIFF
--- a/assets/mapCzech.inline.svg
+++ b/assets/mapCzech.inline.svg
@@ -8,7 +8,7 @@
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    version="1.1"
-   id="Vrstva_1"
+   class="svg-graph-p"
    x="0px"
    y="0px"
    width="720"
@@ -1950,37 +1950,26 @@
 </g>
 <g
    transform="matrix(0.20381699,0,0,0.21544606,81.231824,137.19472)"
-   id="naCPO-g"
-   class="label-mount"
+   class="label-mount naCPO-g"
    inkscape:label="naCPO-g"></g><g
    transform="matrix(0.20381699,0,0,0.21544606,264.6671,163.04825)"
-   id="naSTR-g"
-   class="label-mount"></g><g
+   class="label-mount naSTR-g"></g><g
    transform="matrix(0.20381699,0,0,0.21544606,250.39991,288.00697)"
-   id="naJIC-g"
-   class="label-mount"></g><g
+   class="label-mount naJIC-g"></g><g
    transform="matrix(0.20381699,0,0,0.21544606,566.31622,169.51163)"
-   id="naMPO-g"
-   class="label-mount"></g><g
+   class="label-mount naMPO-g"></g><g
    transform="matrix(0.20381699,0,0,0.21544606,413.4535,156.58487)"
-   id="naSVC-g"
-   class="label-mount"></g><g
+   class="label-mount naSVC-g"></g><g
    transform="matrix(0.20381699,0,0,0.21544606,413.4535,249.22667)"
-   id="naCMO-g"
-   class="label-mount"></g><g
+   class="label-mount naCMO-g"></g><g
    transform="matrix(0.20381699,0,0,0.21544606,668.22472,223.37316)"
-   id="naSLE-g"
-   class="label-mount"></g><g
+   class="label-mount naSLE-g"></g><g
    transform="matrix(0.20381699,0,0,0.21544606,603.00329,316.01496)"
-   id="naVYM-g"
-   class="label-mount"></g><g
+   class="label-mount naVYM-g"></g><g
    transform="matrix(0.20381699,0,0,0.21544606,464.40775,298.77926)"
-   id="naSTM-g"
-   class="label-mount"></g><g
-   id="naZAC-g"
-   class="label-mount"
+   class="label-mount naSTM-g"></g><g
+   class="label-mount naZAC-g"
    transform="matrix(0.20381699,0,0,0.21544606,151.54868,223.37316)"></g><g
-   id="legend-g"
-   class="label-mount"
+   class="label-mount legend-g"
    transform="matrix(0.20381699,0,0,0.21544606,362.49926,438.81921)"></g>
 </svg>

--- a/src/js/conf/index.ts
+++ b/src/js/conf/index.ts
@@ -141,11 +141,15 @@ export interface LayoutConfigTranslatQuery extends LayoutConfigCommon {
     targetLanguages:Array<TranslatLanguage>;
 }
 
+export interface LayoutConfigPreviewQuery extends LayoutConfigCommon {
+    targetLanguages:Array<TranslatLanguage>;
+}
+
 export interface LayoutsConfig {
     single?:LayoutConfigSingleQuery;
     cmp?:LayoutConfigCmpQuery;
     translat?:LayoutConfigTranslatQuery;
-    preview?:LayoutConfigCommon;
+    preview?:LayoutConfigPreviewQuery;
 }
 
 export interface HomePageTileConfI18n {

--- a/src/js/conf/preview.ts
+++ b/src/js/conf/preview.ts
@@ -17,6 +17,7 @@
  */
 import { Dict, List, pipe, tuple } from 'cnc-tskit';
 import { GroupLayoutConfig } from './index.js';
+import { TileConf } from '../page/tile.js';
 
 
 export const queriesConf = [
@@ -25,7 +26,7 @@ export const queriesConf = [
   {word: 'noha', lemma: 'noha', pos: ['N']},
 ]
 
-const tileConf: {[name:string]:any} = {
+const tileConf: {[name:string]:AnyPreviewTileConf} = {
     PREVIEW__wordFreq: {
         tileType: "WordFreqTile",
         label: {
@@ -132,7 +133,6 @@ const tileConf: {[name:string]:any} = {
         subcname: ["9eSmyKII"],
         showMeasuredFreq: true,
         posQueryGenerator: ["tag", "ppTagset"],
-        waitForTimeoutSecs: 10,
         helpURL: "anything",
         subcBacklinkLabel: {
             "9eSmyKII": "pub"
@@ -267,6 +267,55 @@ const tileConf: {[name:string]:any} = {
 };
 
 /**
+ * AnyPreviewTileConf is a mix of all the preview mode tiles' configs.
+ */
+interface AnyPreviewTileConf extends TileConf {
+  apiURL:string;
+  infoApiURL?:string;
+  apiType?:string;
+  corpname?:string;
+  corpName?:string;
+  sentenceStruct?:string;
+  subcname?:unknown;
+  subcorpName?:string;
+  matchCase?:boolean;
+  pixelsPerItem?:number;
+  primaryPackage?:string;
+  srchPackages?:unknown;
+  maxResultItems?:number;
+  subcBacklinkLabel?:unknown;
+  freqType?:string;
+  frequencyDisplayLimit?:number;
+  minMatchFreq?:number;
+  fcrit?:string;
+  audioPlaybackUrl?:string;
+  flimit?:number;
+  fpage?:number;
+  speakerIdAttr?:unknown;
+  speechSegment?:unknown;
+  speechOverlapAttr?:unknown;
+  speechOverlapVal?:string;
+  posQueryGenerator?:unknown;
+  freqSort?:string;
+  fttIncludeEmpty?:boolean;
+  areaCodeMapping?:unknown;
+  showMeasuredFreq?:boolean;
+  pageSize?:number;
+  minFreq?:number;
+  fromYear?:number;
+  toYear?:number;
+  posAttrs?:Array<string>;
+  maxItems?:number;
+  minLocalFreq?:number;
+  maxNumItems?:number;
+  rangeSize?:number;
+  corpusSize?:number;
+  sources?:unknown;
+  freqFilterAlphaLevel?:string;
+  sfwRowRange?:unknown;
+}
+
+/**
  * Create tile configurations for the preview mode. Data that is
  * taken from a hardcoded configuration structure which extended
  * in a way that each tile (e.g. FooTile => {... conf ...}) is entered
@@ -274,11 +323,14 @@ const tileConf: {[name:string]:any} = {
  * allows for using cmp+single supporting tiles in both modes on the same page
  * (with additional tricks performed by tile factory - see mkTileFactory() in tileLoader.ts)
  */
-export function generatePreviewTileConf() {
+export function generatePreviewTileConf():{[name:string]:AnyPreviewTileConf} {
   return pipe(
     tileConf,
     Dict.toEntries(),
-    List.map(([k, v]) => [ tuple(k, v), tuple(k+'2', v)]),
+    List.map(([k, v]) => [
+      tuple(k, v),
+      tuple(k+'2', v)
+    ]),
     List.flatMap(v => v),
     Dict.fromEntries()
   )

--- a/src/js/page/layout.ts
+++ b/src/js/page/layout.ts
@@ -141,8 +141,9 @@ export class LayoutManager {
                     tileMap,
                     appServices,
                     'global__preview_layout'
-                )
-            }
+                ),
+                targetLanguages: layouts.preview.targetLanguages || []
+            } as LayoutOfQueryTypeTranslat
         };
 
         this.validateLayout();

--- a/src/js/page/streaming.ts
+++ b/src/js/page/streaming.ts
@@ -450,7 +450,7 @@ export class DataStreamingPreview implements IDataStreaming {
     }
 
     getId(): string {
-        return "mock";
+        return 'mock';
     }
 
     startNewSubgroup(mainTileId:number, ...dependentTiles:Array<number>):IDataStreaming {

--- a/src/js/tiles/core/geoAreas/index.ts
+++ b/src/js/tiles/core/geoAreas/index.ts
@@ -68,7 +68,6 @@ export class GeoAreasTile implements ITileProvider {
         tileId, dispatcher, appServices, ut, theme,
         widthFract, conf, isBusy, queryMatches, queryType,
     }:TileFactoryArgs<GeoAreasTileConf>) {
-
         this.tileId = tileId;
         this.label = appServices.importExternalMessage(conf.label);
         this.dispatcher = dispatcher;

--- a/src/js/tiles/core/geoAreas/views/compare.tsx
+++ b/src/js/tiles/core/geoAreas/views/compare.tsx
@@ -250,7 +250,7 @@ export function init(dispatcher:IActionDispatcher, ut:ViewUtils<GlobalComponents
         const minIpmNorm = Math.min(...Dict.toEntries(groupedAreaIpmNorms).map(([, v]) => v));
 
         // clear possible previous labels
-        document.querySelectorAll('#svg-graph-p g.label-mount').forEach(elm => {
+        document.querySelectorAll(`section#tile-${tileId} .svg-graph-p  g.label-mount`).forEach(elm => {
             while (elm.firstChild) {
                 elm.removeChild(elm.firstChild);
             }
@@ -259,7 +259,7 @@ export function init(dispatcher:IActionDispatcher, ut:ViewUtils<GlobalComponents
         // insert data
         Dict.forEach(
             (areaIdent, areaName) => {
-                const element = document.getElementById(`${areaIdent}-g`);
+                const element = document.querySelector(`section#tile-${tileId} .svg-graph-p .${areaIdent}-g`);
                 if (element) {
                     let pieChart, areaIpmNorm, scale;
                     const areaData = groupedAreaData[areaName]
@@ -319,7 +319,7 @@ export function init(dispatcher:IActionDispatcher, ut:ViewUtils<GlobalComponents
         );
 
         // insert legend
-        const legendHolder = document.querySelector('#legend-g');
+        const legendHolder = document.querySelector(`section#tile-${tileId} .svg-graph-p .legend-g`);
         createSVGLegend(legendHolder, currentQueryMatches);
     }
 

--- a/src/js/tiles/core/geoAreas/views/single.tsx
+++ b/src/js/tiles/core/geoAreas/views/single.tsx
@@ -79,7 +79,7 @@ export function init(dispatcher:IActionDispatcher, ut:ViewUtils<GlobalComponents
         const mkSize = (v:number) => a * v + b;
 
         // clear possible previous labels
-        document.querySelectorAll('#svg-graph-p g.label-mount').forEach(elm => {
+        document.querySelectorAll(`section#tile-${tileId} .svg-graph-p g.label-mount`).forEach(elm => {
             while (elm.firstChild) {
                 elm.removeChild(elm.firstChild);
             }
@@ -87,7 +87,7 @@ export function init(dispatcher:IActionDispatcher, ut:ViewUtils<GlobalComponents
 
         // insert data
         Dict.forEach((areaIdent, areaName) => {
-            const elm = document.getElementById(`${areaIdent}-g`);
+            const elm = document.querySelector(`section#tile-${tileId} .svg-graph-p .${areaIdent}-g`);
             if (elm) {
                 let label;
                 const areaIndex = List.findIndex((v, i) => v.name === areaName, props.data[0]);


### PR DESCRIPTION
1) preview mode - fix missing translat. languages for the "translations"
   section
2) from the Czech map svg, stop using elm IDs for attaching other svg
   elements as this does not allow having multiple maps per single page