### PR TITLE
Extend theming beyond chart colors

### DIFF
--- a/conf/themes.json
+++ b/conf/themes.json
@@ -1,48 +1,54 @@
 {
-    "default": "devel2",
+    "default": "cnc-default",
     "themes": [
         {
-            "themeId": "devel1",
-            "themeLabel": "Devel 1",
+            "themeId": "cnc-default",
+            "themeLabel": "CNC default",
+            "lineChartColor1": "#009ee0",
+            "lineConfidenceAreaColor1": "#ddedf3",
+            "lineChartColor2": "#E2007A",
+            "lineConfidenceAreaColor2": "#eed4e2",
             "cmpCategory": [
-                "#009ee0",
-                "#6692eb",
-                "#a87fe1",
-                "#db66c1",
-                "#fa5090",
-                "#ff5056",
-                "#ea670c"
+                "#009EE0",
+                "#E2007A",
+                "#57AB27",
+                "#EA670C",
+                "#000075",
+                "#9A6324",
+                "#FFE119",
+                "#FABED4"
             ],
             "category": [
-                "#60CFFF",
-                "#94A3FF",
-                "#FFDC84",
-                "#FFB058",
-                "#53a82c",
-                "#8ADCFF",
-                "#C1C9FF",
-                "#FFEBB8",
-                "#FFC584"
+               "#009EE0",
+                "#E2007A",
+                "#57AB27",
+                "#EA670C",
+                "#000075",
+                "#9A6324",
+                "#FFE119",
+                "#FABED4"
             ],
-            "categoryOther": "#494949",
-            "scale": [
-                "#60CFFF",
-                "#8ADCFF",
-                "#94A3FF",
-                "#C1C9FF",
-                "#FFDC84",
-                "#FFEBB8",
-                "#FFB058",
-                "#FFC584",
-                "#FFC584",
-                "#FFC584",
-                "#FFC584"
-            ],
-            "geoAreaSpotFillColor": "#009ee0"
+           "categoryOther": "#494949",
+           "scale": [
+                "#009EE0",
+                "#66C5EC",
+                "#A93F9F",
+                "#D49FCF",
+                "#EA9358",
+                "#F5C9AB",
+                "#A5A94B",
+                "#D2D4A5",
+                "#D2D4A5",
+                "#D2D4A5",
+                "#D2D4A5",
+                "#D2D4A5"
+           ],
+           "geoAreaSpotFillColor": "#009ee0",
+           "geoAreaSpotTextColor": "#FFFFFF"
         },
         {
-            "themeId": "devel2",
-            "themeLabel": "Devel 2",
+            "themeId": "cvd",
+            "themeLabel": "Color vision deficiency",
             "cmpCategory": [
                 "#F4917C",
                 "#EF8FA7",
@@ -85,39 +91,6 @@
             "themeLabel": "Dynamic",
             "cmpCategory": [
                 "#60CFFF"
-            ],
-            "category": [
-                "#60CFFF",
-                "#94A3FF",
-                "#FFDC84",
-                "#FFB058",
-                "#53a82c",
-                "#8ADCFF",
-                "#C1C9FF",
-                "#FFEBB8",
-                "#FFC584"
-           ],
-           "categoryOther": "#494949",
-           "scale": [
-                "#60CFFF",
-                "#8ADCFF",
-                "#94A3FF",
-                "#C1C9FF",
-                "#FFDC84",
-                "#FFEBB8",
-                "#FFB058",
-                "#FFC584",
-                "#FFC584",
-                "#FFC584",
-                "#FFC584"
-           ],
-           "geoAreaSpotFillColor": "#009ee0"
-        },
-        {
-            "themeId": "auto-color",
-            "themeLabel": "Auto color",
-            "cmpCategory": [
-                "#F8766D"
             ],
             "category": [
                 "#60CFFF",

--- a/src/js/app.ts
+++ b/src/js/app.ts
@@ -130,11 +130,12 @@ export function createRootComponent({
     tileGroups:Array<TileGroup>,
     mainPosAttr:MainPosAttrValues
  } {
-    const globalComponents = globalCompInit(dispatcher, viewUtils, onResize);
+    const theme = new Theme(config.colors);
+    const globalComponents = globalCompInit(dispatcher, viewUtils, onResize, theme);
     viewUtils.attachComponents(globalComponents);
 
     const tiles:Array<TileFrameProps> = [];
-    const theme = new Theme(config.colors);
+
     const qType = userSession.queryType as QueryType; // TODO validate
 
     const formModel = mainFormFactory({
@@ -235,7 +236,8 @@ export function createRootComponent({
     );
     const messagesModel = new MessagesModel(dispatcher, appServices);
 
-    const WdglanceMain = viewInit(dispatcher, viewUtils, formModel, tilesModel, messagesModel);
+    const WdglanceMain = viewInit(
+        dispatcher, viewUtils, formModel, tilesModel, messagesModel, theme);
 
     onResize.subscribe(
         (props) => {

--- a/src/js/conf/index.ts
+++ b/src/js/conf/index.ts
@@ -82,6 +82,30 @@ export interface ColorThemeIdent {
  * (mainly chart colors).
  */
 export interface ColorTheme extends ColorThemeIdent {
+
+    defaultFontFamily?:string;
+    condensedFontFamily?:string;
+    defaultFontSize?:string;
+    backgroundImage?:string;
+    pageBackgroundColor?:string;
+    tileBackgroundColor?:string;
+    colorLogoBlue?:string;
+    colorLogoBlueShining?:string;
+    colorWhitelikeBlue?:string;
+    colorLightText?:string;
+    colorDefaultText?:string;
+    colorInvertText?:string;
+    colorInvertedSecondaryText?:string;
+    colorSecondaryText?:string;
+    colorLogoPink?:string;
+    colorSuperlightGrey?:string;
+    svgIconsFilter?:string;
+
+
+    cssMediaMediumSize?:string;
+    cssMediaSmallSize?:string;
+
+
     lineChartColor1:string;
     lineConfidenceAreaColor1:string;
     lineChartColor2:string;

--- a/src/js/page/theme.ts
+++ b/src/js/page/theme.ts
@@ -17,6 +17,8 @@
  */
 import { ColorTheme } from '../conf/index.js';
 import { Dict, Color, pipe, List } from 'cnc-tskit';
+import * as theme from '../views/common/theme.js';
+import grooveBg from '../../../assets/groovepaper2.jpg';
 
 
 export enum SystemColor {
@@ -41,6 +43,16 @@ const defaultTheme:ColorTheme = {
 
     themeId: 'default',
     themeLabel: 'Default',
+
+    // text color
+
+    pageBackgroundColor: '#ffffff',
+
+    tileBackgroundColor: '#ffffff',
+
+
+    // charts
+
     lineChartColor1: "#DD8959",
     lineConfidenceAreaColor1: "#f2d9ca",
     lineChartColor2: "#1334FF",
@@ -84,6 +96,51 @@ const defaultTheme:ColorTheme = {
  */
 export class Theme {
 
+    public readonly ident:string;
+
+    // main styling
+
+    public readonly pageBackgroundColor:string|undefined;
+
+    public readonly tileBackgroundColor:string|undefined;
+
+    public readonly defaultFontFamily:string;
+
+    public readonly condensedFontFamily:string;
+
+    public readonly defaultFontSize:string;
+
+    public readonly backgroundImage:string|undefined;
+
+    public readonly colorLogoBlue:string;
+
+    public readonly colorWhitelikeBlue:string;
+
+    public readonly colorDefaultText:string;
+
+    public readonly colorInvertText:string;
+
+    public readonly colorSecondaryText:string;
+
+    public readonly colorLightText:string;
+
+    public readonly colorLogoPink:string;
+
+    public readonly colorSuperlightGrey:string;
+
+    public readonly colorLogoBlueShining:string;
+
+    public readonly colorInvertedSecondaryText:string;
+
+
+    public readonly cssMediaMediumSize:string;
+
+    public readonly cssMediaSmallSize:string;
+
+    public readonly svgIconsFilter:string|undefined;
+
+
+
     private readonly catColors:Array<string>;
 
     // this is auto-generated
@@ -115,7 +172,32 @@ export class Theme {
     public readonly lineConfidenceAreaColor2:string;
 
     constructor(conf?:ColorTheme) {
+
         const confSrc = conf && Dict.size<any, string>(conf) > 0 ? conf : defaultTheme;
+        this.ident = confSrc.themeId;
+
+        this.defaultFontFamily = confSrc.defaultFontFamily || theme.defaultFontFamily;
+        this.condensedFontFamily = confSrc.condensedFontFamily || theme.condensedFontFamily;
+        this.defaultFontSize = confSrc.defaultFontSize || '1em';
+        this.backgroundImage = confSrc.backgroundImage || `url(${grooveBg})`;
+        this.pageBackgroundColor = confSrc.pageBackgroundColor || defaultTheme.pageBackgroundColor;
+        this.tileBackgroundColor = confSrc.tileBackgroundColor || defaultTheme.tileBackgroundColor;
+        this.colorLogoBlue = confSrc.colorLogoBlue || theme.colorLogoBlue;
+        this.colorWhitelikeBlue = confSrc.colorWhitelikeBlue || theme.colorWhitelikeBlue;
+        this.colorLightText = confSrc.colorLightText || theme.colorLightText;
+        this.colorDefaultText = confSrc.colorDefaultText || theme.colorDefaultText;
+        this.colorInvertText = confSrc.colorInvertText || theme.colorInvertedSecondary;
+        this.colorSecondaryText = confSrc.colorSecondaryText || theme.colorInvertedSecondary;
+        this.colorLogoPink = confSrc.colorLogoPink || theme.colorLogoPink;
+        this.colorSuperlightGrey = confSrc.colorSuperlightGrey || theme.colorSuperlightGrey;
+        this.colorLogoBlueShining = confSrc.colorLogoBlueShining || theme.colorLogoBlueShining;
+        this.colorInvertedSecondaryText = confSrc.colorInvertedSecondaryText || theme.colorInvertedSecondary;
+
+        this.cssMediaMediumSize = confSrc.cssMediaMediumSize || theme.media.medium;
+        this.cssMediaSmallSize = confSrc.cssMediaSmallSize || theme.media.small;
+        this.svgIconsFilter = confSrc.svgIconsFilter;
+
+
         this.catColors = confSrc.category || [];
         this.catColorsHighlighted = List.map(
             color => pipe(

--- a/src/js/server/routes/index.ts
+++ b/src/js/server/routes/index.ts
@@ -43,6 +43,7 @@ import { DataStreaming } from '../../page/streaming.js';
 import { createInstance, FreqDBType } from '../freqdb/factory.js';
 import urlJoin from 'url-join';
 import { ServerNotifications } from '../../page/notifications.js';
+import { Theme } from '../../page/theme.js';
 
 const LANG_COOKIE_TTL = 3600 * 24 * 365;
 
@@ -64,7 +65,7 @@ export function errorPage({req, res, uiLang, services, viewUtils, error}:ErrorPa
     );
     const clientConfig = emptyClientConf(services.clientConf, req.cookies[THEME_COOKIE_NAME]);
     clientConfig.colorThemes = [];
-    const {HtmlBody, HtmlHead} = viewInit(viewUtils);
+    const {HtmlBody, HtmlHead} = viewInit(viewUtils, new Theme());
     const errView = errPageInit(viewUtils);
     res
         .status(HTTP.Status.NotFound)

--- a/src/js/server/routes/main.ts
+++ b/src/js/server/routes/main.ts
@@ -50,6 +50,7 @@ import { createInstance, FreqDBType } from '../freqdb/factory.js';
 import urlJoin from 'url-join';
 import { TileConf } from '../../page/tile.js';
 import { queriesConf, previewLayoutConf } from '../../conf/preview.js';
+import { Theme } from '../../page/theme.js';
 
 
 interface MkRuntimeClientConfArgs {
@@ -534,7 +535,9 @@ export function queryAction({
                 layoutManager
             });
 
-            const {HtmlHead, HtmlBody} = viewInit(viewUtils);
+            const currTheme = new Theme(getAppliedThemeConf(services.clientConf));
+
+            const {HtmlHead, HtmlBody} = viewInit(viewUtils, currTheme);
             // Here we're going to use the fact that (the current)
             // server-side action dispatcher does not trigger side effects
             // so our models just set 'busy' state and nothing else happens.
@@ -579,9 +582,9 @@ export function queryAction({
             const error:[number, string] = [HTTP.Status.BadRequest, err.message];
             const userConf = errorUserConf(
                 services.clientConf.applicationId, services.serverConf.languages, error, uiLang);
-            const { HtmlHead, HtmlBody } = viewInit(viewUtils);
+            const currTheme = new Theme(getAppliedThemeConf(services.clientConf));
+            const { HtmlHead, HtmlBody } = viewInit(viewUtils, currTheme);
             const errView = errPageInit(viewUtils);
-            const currTheme = getAppliedThemeConf(services.clientConf);
             res.send(renderResult({
                 HtmlBody,
                 HtmlHead,
@@ -589,7 +592,7 @@ export function queryAction({
                 toolbarData: emptyValue(),
                 queryMatches: [],
                 themes: [],
-                currTheme: currTheme.themeId,
+                currTheme: currTheme.ident,
                 userConfig: userConf,
                 currentParentWagPageUrl: undefined,
                 clientConfig: emptyClientConf(services.clientConf, req.cookies[THEME_COOKIE_NAME]),

--- a/src/js/tiles/core/colloc/style.tsx
+++ b/src/js/tiles/core/colloc/style.tsx
@@ -18,10 +18,10 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { Theme } from '../../../page/theme.js';
 import { styled } from 'styled-components';
-import * as theme from '../../../views/common/theme.js';
 
-export const Boxes = styled.div<{$isMobile:boolean}>`
+export const Boxes = styled.div<{$isMobile:boolean, theme:Theme}>`
     overflow-y: hidden;
     overflow-x: auto;
     display: flex;
@@ -33,7 +33,7 @@ export const Boxes = styled.div<{$isMobile:boolean}>`
     & > .chart {
         min-width: 50%;
 
-        ${theme.media.medium} {
+        ${props => props.theme.cssMediaMediumSize} {
             min-width: initial;
             width: 100%;
         }
@@ -44,14 +44,14 @@ export const Boxes = styled.div<{$isMobile:boolean}>`
     }
 `;
 
-export const CollocCloud = styled.div`
+export const CollocCloud = styled.div<{theme:Theme}>`
     h2 {
         text-align: center;
         font-weight: normal;
         font-size: 1.4em;
         padding-bottom: 0.3em;
         padding-left: 0.7em;
-        border-color: ${theme.colorLightGrey};
+        border-color: ${props => props.theme.colorInvertedSecondaryText};
         border-style: solid;
         border-width: 0 0 1px 0;
         margin: 0 0.5em 1em 0.5em;

--- a/src/js/tiles/core/concordance/style.tsx
+++ b/src/js/tiles/core/concordance/style.tsx
@@ -18,19 +18,19 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { Theme } from '../../../page/theme.js';
 import { styled } from 'styled-components';
-import * as theme from '../../../views/common/theme.js';
 
 export const ConcordanceTileView = styled.div`
     overflow: hidden;
 `;
 
-export const QueryInfo = styled.p`
+export const QueryInfo = styled.p<{theme:Theme}>`
     font-size: 1.2em;
 
     a.variant {
         cursor: pointer;
-        color: ${theme.colorDefaultText};
+        color: ${props => props.theme.colorDefaultText};
         font-weight: bold;
         text-decoration: none;
     }
@@ -40,7 +40,7 @@ export const QueryInfo = styled.p`
     }
 `;
 
-export const Summary = styled.dl`
+export const Summary = styled.dl<{theme:Theme}>`
     margin-top: 0.7em;
     margin-bottom: 1.5em;
 
@@ -50,14 +50,14 @@ export const Summary = styled.dl`
     }
 
     dt {
-        font-family: ${theme.condensedFontFamily};
-        color: ${theme.colorLightText};
+        font-family: ${props => props.theme.condensedFontFamily};
+        color: ${props => props.theme.colorLightText};
     }
 
     dd {
         font-weight: bold;
         margin-left: 0.3em;
-        color: ${theme.colorLightText};
+        color: ${props => props.theme.colorLightText};
     }
 
     dd:not(:last-child)::after {
@@ -70,13 +70,13 @@ export const Summary = styled.dl`
     }
 `;
 
-export const LineMetadata = styled.div`
+export const LineMetadata = styled.div<{theme:Theme}>`
     max-width: 30em;
     position: absolute;
     padding: 1em;
     background-color: #FFFFFF;
     margin-left: 0em;
-    border: 1px solid ${theme.colorLightGrey};
+    border: 1px solid ${props => props.theme.colorInvertedSecondaryText};
     border-radius: 3px;
     border-spacing: 0;
     border-collapse: collapse;
@@ -105,8 +105,8 @@ export const LineMetadata = styled.div`
     }
 `;
 
-export const ConcLines = styled.div`
-    font-family: ${theme.condensedFontFamily};
+export const ConcLines = styled.div<{theme:Theme}>`
+    font-family: ${props => props.theme.condensedFontFamily};
     display: flex;
     justify-content: center;
     border-spacing: 0;
@@ -130,13 +130,13 @@ export const ConcLines = styled.div`
             display: inline-block;
             padding-left: 0.3em;
             padding-right: 0.3em;
-            color: ${theme.colorLogoPink};
+            color: ${props => props.theme.colorLogoPink};
         }
     }
 
     tr.separator:not(:last-of-type) td {
         border-width: 0 0 1px 0;
-        border-color: ${theme.colorLightGrey};
+        border-color: ${props => props.theme.colorInvertedSecondaryText};
         border-style: solid;
     }
 
@@ -148,7 +148,7 @@ export const ConcLines = styled.div`
         display: block;
 
         tr:nth-child(odd) {
-            background-color: ${theme.colorWhitelikeBlue};
+            background-color: ${props => props.theme.colorWhitelikeBlue};
         }
 
         tr {
@@ -173,7 +173,7 @@ export const ConcLines = styled.div`
     }
 `;
 
-export const Row = styled.tr`
+export const Row = styled.tr<{theme:Theme}>`
     white-space: nowrap;
 
     td {
@@ -193,11 +193,11 @@ export const Row = styled.tr`
         padding-left: 0.5em;
         padding-right: 0.5em;
         text-align: center;
-        color: ${theme.colorLogoPink};
+        color: ${props => props.theme.colorLogoPink};
     }
 
     td .coll {
-        color: ${theme.colorLogoPink};
+        color: ${props => props.theme.colorLogoPink};
         font-style: italic;
         display: inline-block;
         padding-left: 0.2em;
@@ -206,10 +206,10 @@ export const Row = styled.tr`
 `;
 
 
-export const SentRow = styled.tr`
+export const SentRow = styled.tr<{theme:Theme}>`
 
     &.highlighted {
-        background-color: ${theme.colorDataHighlightRow};
+        background-color: ${props => props.theme.colorDataHighlightRow};
     }
 
     white-space: inherit;
@@ -220,7 +220,7 @@ export const SentRow = styled.tr`
     }
 
     td .coll {
-        color: ${theme.colorLogoPink};
+        color: ${props => props.theme.colorLogoPink};
         font-style: italic;
         display: inline-block;
         padding-left: 0.2em;
@@ -229,7 +229,7 @@ export const SentRow = styled.tr`
 
 `;
 
-export const Controls = styled.form`
+export const Controls = styled.form<{theme:Theme}>`
     margin-bottom: 0.7em;
 
     fieldset {

--- a/src/js/tiles/core/concordance/views.tsx
+++ b/src/js/tiles/core/concordance/views.tsx
@@ -230,7 +230,7 @@ export function init(dispatcher:IActionDispatcher, ut:ViewUtils<GlobalComponents
                     {!props.isParallel && !!props.data.props && !Dict.empty(props.data.props) ?
                         <td className="meta" rowSpan={props.isFirstOfLinePair ? 2 : 1}>
                             <a className="info-click" onClick={props.handleLineClick}>
-                                <img src={ut.createStaticUrl('info-icon.svg')} alt={ut.translate('global__img_alt_info_icon')} />
+                                <img className="filtered" src={ut.createStaticUrl('info-icon.svg')} alt={ut.translate('global__img_alt_info_icon')} />
                             </a>
                         </td> :
                         null
@@ -269,7 +269,7 @@ export function init(dispatcher:IActionDispatcher, ut:ViewUtils<GlobalComponents
                     {!!props.data.props && !Dict.empty(props.data.props) ?
                         <td className="meta">
                             <a className="info-click" onClick={props.handleLineClick}>
-                                <img src={ut.createStaticUrl('info-icon.svg')} alt={ut.translate('global__img_alt_info_icon')} />
+                                <img className="filtered" src={ut.createStaticUrl('info-icon.svg')} alt={ut.translate('global__img_alt_info_icon')} />
                             </a>
                         </td> :
                         null

--- a/src/js/tiles/core/speeches/style.tsx
+++ b/src/js/tiles/core/speeches/style.tsx
@@ -18,11 +18,12 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { Theme } from '../../../page/theme.js';
 import { styled } from 'styled-components';
-import * as theme from '../../../views/common/theme.js';
 
+// -------------- <SpeechesTile /> -----------------
 
-export const SpeechesTile = styled.div`
+export const SpeechesTile = styled.div<{theme:Theme}>`
     tr.expand {
 
         th {
@@ -78,7 +79,10 @@ export const SpeechesTile = styled.div`
     }
 `;
 
-export const Speeches = styled.dl`
+
+// -------------- <Speeches /> -----------------
+
+export const Speeches = styled.dl<{theme:Theme}>`
     border-spacing: 0;
 
     dd, dt {
@@ -86,11 +90,13 @@ export const Speeches = styled.dl`
     }
 `;
 
-export const Speaker = styled.dt`
+// -------------- <Speaker /> -----------------
+
+export const Speaker = styled.dt<{theme:Theme}>`
     text-align: left;
     strong {
-        border: 1px solid ${theme.colorLightText};
-        border-radius: ${theme.defaultBorderRadius};
+        border: 1px solid ${props => props.theme.colorLightText};
+        border-radius: ${props => props.theme.defaultBorderRadius};
         display: inline-block;
         vertical-align: middle;
         font-size: 0.8em;
@@ -102,6 +108,8 @@ export const Speaker = styled.dt`
         margin-top: 1.2em;
     }
 `;
+
+// -------------- <Speech /> -----------------
 
 export const Speech = styled.dd`
     margin-top: 0.3em;
@@ -127,12 +135,14 @@ export const Speech = styled.dd`
     }
 
     .coll {
-        color: ${theme.colorLogoPink};
+        color: ${props => props.theme.colorLogoPink};
         font-weight: bold;
     }
 `;
 
-export const PlayerIcon = styled.a`
+// -------------- <PlayerIcon /> -----------------
+
+export const PlayerIcon = styled.a<{theme:Theme}>`
     display: inline-block;
     vertical-align: middle;
     margin-left: 1em;

--- a/src/js/tiles/core/speeches/view.tsx
+++ b/src/js/tiles/core/speeches/view.tsx
@@ -186,7 +186,7 @@ export function init(
 
         return (
             <a style={props.active ? null : {pointerEvents: 'none', cursor: 'default'}} onClick={handleClick} title={ut.translate('speeches__load_different_sp_button')}>
-                <img src={ut.createStaticUrl(props.active ? 'next.svg' : 'next_grey.svg')} style={{width: '1.8em'}} alt={ut.translate('speeches__load_different_sp_button')} />
+                <img className="filtered" src={ut.createStaticUrl(props.active ? 'next.svg' : 'next_grey.svg')} style={{width: '1.8em'}} alt={ut.translate('speeches__load_different_sp_button')} />
             </a>
         );
     };
@@ -214,7 +214,7 @@ export function init(
 
         return (
             <S.PlayerIcon onClick={handleClick}>
-                <img src={ut.createStaticUrl(props.isPlaying ? 'audio-3w.svg' : 'audio-0w.svg')}
+                <img className="filtered" src={ut.createStaticUrl(props.isPlaying ? 'audio-3w.svg' : 'audio-0w.svg')}
                         alt={ut.translate('global__img_alt_play_audio')} />
             </S.PlayerIcon>
         )

--- a/src/js/tiles/core/syntacticColls/style.tsx
+++ b/src/js/tiles/core/syntacticColls/style.tsx
@@ -17,7 +17,7 @@
  */
 
 import { styled } from 'styled-components';
-import * as theme from '../../../views/common/theme.js';
+import { Theme } from '../../../page/theme.js';
 
 export const SyntacticColls = styled.div`
 
@@ -43,7 +43,7 @@ export const SCollsWordCloud = styled.div`
 
 // ------------------- <SCollsTable /> ------------------------
 
-export const SCollsTable = styled.div`
+export const SCollsTable = styled.div<{theme:Theme}>`
     flex-grow: 1;
 
     h2 {
@@ -60,21 +60,21 @@ export const SCollsTable = styled.div`
         }
 
         .arrows {
-            color: ${theme.colorLogoPink};
+            color: ${props => props.theme.colorLogoPink};
         }
 
         .fn {
-            color: ${theme.colorLightText};
+            color: ${props => props.theme.colorLightText};
         }
 
     }
 `;
 
 
-export const Examples = styled.div`
+export const Examples = styled.div<{theme:Theme}>`
     background-color: #fefefe;
-    border: ${theme.defaultBorderStyle};
-    border-radius: ${theme.defaultBorderRadius};
+    border: ${props => props.theme.defaultBorderStyle};
+    border-radius: ${props => props.theme.defaultBorderRadius};
     box-shadow: .05em .05em .15em .05em rgba(0, 0, 0, 0.2);
     padding: 0.5em;
 
@@ -89,7 +89,7 @@ export const Examples = styled.div`
             padding: 0.5em 1em 0.5em 1em;
 
             strong {
-                color: ${theme.colorLogoPink};
+                color: ${props => props.theme.colorLogoPink};
             }
         }
 
@@ -111,11 +111,11 @@ export const Examples = styled.div`
             padding-left: 1em;
 
             span.words {
-                color: ${theme.colorLogoPink};
+                color: ${props => props.theme.colorLogoPink};
                 font-weight: normal;
 
                 span.plus {
-                    color: ${theme.colorDefaultText};
+                    color: ${props => props.theme.colorDefaultText};
                 }
             }
         }

--- a/src/js/tiles/core/syntacticColls/views.tsx
+++ b/src/js/tiles/core/syntacticColls/views.tsx
@@ -75,7 +75,7 @@ export function init(
                 </h3>
                 <div className="controls">
                     <a onClick={onClose} className="close">
-                        <img src={ut.createStaticUrl('close-icon.svg')} alt={ut.translate('global__img_alt_close_icon')} />
+                        <img className="filtered" src={ut.createStaticUrl('close-icon.svg')} alt={ut.translate('global__img_alt_close_icon')} />
                     </a>
                 </div>
             </div>

--- a/src/js/tiles/core/treqSubsets/style.tsx
+++ b/src/js/tiles/core/treqSubsets/style.tsx
@@ -18,18 +18,23 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { Theme } from '../../../page/theme.js';
 import { styled } from 'styled-components';
-import * as theme from '../../../views/common/theme.js';
 
 
-export const TreqSubsetsView = styled.div`
+// --------------------- <TreqSubsetsView /> ----------------------
+
+export const TreqSubsetsView = styled.div<{theme:Theme}>`
     .data {
         overflow-x: auto;
         overflow-y: hidden;
     }
 `;
 
-export const AltViewTable = styled.table`
+
+// --------------------- <AltViewTable /> ----------------------
+
+export const AltViewTable = styled.table<{theme:Theme}>`
     th.word {
         text-align: right;
         padding-right: 0.7em;
@@ -41,7 +46,9 @@ export const AltViewTable = styled.table`
     }
 `;
 
-export const ChartLikeTable = styled.table`
+// --------------------- <ChartLikeTable /> ----------------------
+
+export const ChartLikeTable = styled.table<{theme:Theme}>`
     border-spacing: 0;
     border-collapse: collapse;
 
@@ -66,7 +73,7 @@ export const ChartLikeTable = styled.table`
     }
 
     tr.highlighted {
-        background-color: ${theme.colorDataHighlightRow};
+        background-color: ${props => props.theme.colorDataHighlightRow};
     }
 
     .SimpleBar {
@@ -89,7 +96,9 @@ export const ChartLikeTable = styled.table`
     }
 `;
 
-export const SimpleBar = styled.svg`
+// --------------------- <SimpleBar /> ----------------------
+
+export const SimpleBar = styled.svg<{theme:Theme}>`
     .bar {
         position: absolute;
         margin-top: 5px;

--- a/src/js/tiles/core/wordFreq/style.tsx
+++ b/src/js/tiles/core/wordFreq/style.tsx
@@ -19,10 +19,12 @@
  */
 
 import { styled } from 'styled-components';
-import * as theme from '../../../views/common/theme.js';
+import { Theme } from '../../../page/theme.js';
 
 
-export const WordFreqTileView = styled.div`
+// ------------- <WordFreqTileView /> -----------------------------
+
+export const WordFreqTileView = styled.div<{theme:Theme}>`
     display: flex;
     align-items: stretch;
     justify-content: space-between;
@@ -47,8 +49,8 @@ export const WordFreqTileView = styled.div`
 
         dt {
             margin-bottom: 0.4em;
-            color: ${theme.colorLightText};
-            font-family: ${theme.condensedFontFamily};
+            color: ${props => props.theme.colorLightText};
+            font-family: ${props => props.theme.condensedFontFamily};
         }
 
         dd {
@@ -56,7 +58,7 @@ export const WordFreqTileView = styled.div`
             margin-left: 1em;
 
             span.squareb {
-                color: ${theme.colorLightText};
+                color: ${props => props.theme.colorLightText};
             }
         }
 
@@ -67,19 +69,19 @@ export const WordFreqTileView = styled.div`
         dd.word-list {
             font-size: 1.3em;
             a {
-                color: ${theme.colorDefaultText};
+                color: ${props => props.theme.colorDefaultText};
                 cursor: pointer;
                 text-decoration: none;
             }
 
             a:hover {
-                color: ${theme.colorLogoBlue};
+                color: ${props => props.theme.colorLogoBlue};
                 text-decoration: underline;
             }
         }
     }
 
-    ${theme.media.small} {
+    ${props => props.theme.cssMediaSmallSize} {
         flex-direction: column;
 
         & > div.cell h3 {
@@ -88,7 +90,10 @@ export const WordFreqTileView = styled.div`
     }
 `;
 
-export const Stars = styled.span`
+
+// ------------- <Stars /> -----------------------------
+
+export const Stars = styled.span<{theme:Theme}>`
     display: block;
     white-space: nowrap;
 
@@ -97,13 +102,15 @@ export const Stars = styled.span`
     }
 `;
 
-export const MultiWordProfile = styled.div`
+// ------------- <MultiWordProfile /> -----------------------------
+
+export const MultiWordProfile = styled.div<{theme:Theme}>`
     & > table {
 
         border-spacing: 2px 4px;
 
         thead th {
-            color: ${theme.colorLightText};
+            color: ${props => props.theme.colorLightText};
             text-align: right;
         }
 
@@ -113,8 +120,8 @@ export const MultiWordProfile = styled.div`
         }
 
         th.query-num {
-            background-color: ${theme.colorLightGrey};
-            color: ${theme.colorDefaultText};
+            background-color: ${props => props.theme.colorInvertedSecondaryText};
+            color: ${props => props.theme.colorDefaultText};
             border-radius: 0.3em;
         }
 

--- a/src/js/tiles/core/wordFreq/views/common.tsx
+++ b/src/js/tiles/core/wordFreq/views/common.tsx
@@ -32,7 +32,7 @@ export function init(dispatcher:IActionDispatcher, ut:ViewUtils<GlobalComponents
 
     }> = (props) => {
         return <S.Stars>{[1, 2, 3, 4, 5].map(v =>
-            <img key={`${v}`} src={ut.createStaticUrl(`star${v <= props.freqBand ? '' : '_grey'}.svg`)}
+            <img className="filtered" key={`${v}`} src={ut.createStaticUrl(`star${v <= props.freqBand ? '' : '_grey'}.svg`)}
                  alt={ut.translate(v <= props.freqBand ? 'global__img_alt_star_icon' : 'global__img_alt_star_icon_grey')} />
         )}</S.Stars>
     };

--- a/src/js/tiles/core/wordSim/style.tsx
+++ b/src/js/tiles/core/wordSim/style.tsx
@@ -18,15 +18,16 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { Theme } from '../../../page/theme.js';
 import { styled } from 'styled-components';
-import * as theme from '../../../views/common/theme.js';
+
 
 
 export const WordSimView = styled.div`
     height: 100%;
 `;
 
-export const Boxes = styled.div<{$isMobile:boolean}>`
+export const Boxes = styled.div<{$isMobile:boolean, theme:Theme}>`
     height: 100%;
     overflow-y: hidden;
     overflow-x: auto;
@@ -44,7 +45,7 @@ export const Boxes = styled.div<{$isMobile:boolean}>`
         margin-right: 0.7em;
     }
 
-    ${theme.media.medium} {
+    ${props => props.theme.cssMediaMediumSize} {
         & > .chart {
             min-width: initial;
             width: 100%;
@@ -52,7 +53,7 @@ export const Boxes = styled.div<{$isMobile:boolean}>`
     }
 `;
 
-export const SimCloud = styled.div`
+export const SimCloud = styled.div<{theme:Theme}>`
     height: 100%;
     display: flex;
     flex-direction: column;
@@ -63,7 +64,7 @@ export const SimCloud = styled.div`
         font-size: 1.4em;
         padding-bottom: 0.3em;
         padding-left: 0.7em;
-        border-color: ${theme.colorLightGrey};
+        border-color: ${props => props.theme.colorInvertedSecondaryText};
         border-style: solid;
         border-width: 0 0 1px 0;
         margin: 0 0.5em 1em 0.5em;

--- a/src/js/tiles/custom/template/style.tsx
+++ b/src/js/tiles/custom/template/style.tsx
@@ -1,5 +1,5 @@
 import { styled } from 'styled-components';
-import * as theme from '../../../views/common/theme.js';
+
 
 export const __Template__Tile = styled.div`
 `;

--- a/src/js/views/common/index.tsx
+++ b/src/js/views/common/index.tsx
@@ -27,6 +27,7 @@ import { Actions } from '../../models/actions.js';
 
 import * as S from './style.js';
 import { SourceCitation } from '../../api/abstract/sourceInfo.js';
+import { Theme } from '../../page/theme.js';
 
 
 export interface SourceInfo {
@@ -138,8 +139,11 @@ export interface GlobalComponents {
 export function init(
     dispatcher:IActionDispatcher,
     ut:ViewUtils<{}>,
-    resize$:Observable<ScreenProps>
+    resize$:Observable<ScreenProps>,
+    theme:Theme
 ):GlobalComponents {
+
+
 
     // --------------- <AjaxLoader /> -------------------------------------------
 
@@ -589,7 +593,7 @@ export function init(
                                     onClick={this.props.onCloseClick}
                                     onKeyDown={this.handleKey}
                                     title={ut.translate('global__close_modal')}>
-                                <img src={ut.createStaticUrl('close-icon.svg')} alt={ut.translate('global__img_alt_close_icon')} />
+                                <img className="filtered" src={ut.createStaticUrl('close-icon.svg')} alt={ut.translate('global__img_alt_close_icon')} />
                             </button>
                         </header>
                         <div className={tileClasses}>
@@ -853,12 +857,12 @@ export function init(
         return (
             <S.Paginator>
                 <a onClick={props.onPrev} className={`${props.page === 1 ? 'disabled' : null}`}>
-                    <img className="arrow" src={ut.createStaticUrl(props.page === 1 ? 'triangle_left_gr.svg' : 'triangle_left.svg')}
+                    <img className="filtered arrow" src={ut.createStaticUrl(props.page === 1 ? 'triangle_left_gr.svg' : 'triangle_left.svg')}
                         alt={ut.translate('global__img_alt_triable_left')} />
                 </a>
                 <input className="page" type="text" readOnly={true} value={props.page} />
                 <a onClick={props.onNext} className={`${props.page === props.numPages ? 'disabled' : null}`}>
-                    <img className="arrow" src={ut.createStaticUrl(props.page === props.numPages ? 'triangle_right_gr.svg' : 'triangle_right.svg')}
+                    <img className="filtered arrow" src={ut.createStaticUrl(props.page === props.numPages ? 'triangle_right_gr.svg' : 'triangle_right.svg')}
                         alt={ut.translate('global__img_alt_triable_right')} />
                 </a>
             </S.Paginator>

--- a/src/js/views/common/style.tsx
+++ b/src/js/views/common/style.tsx
@@ -18,8 +18,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
+import { Theme } from '../../page/theme.js';
 import { styled } from 'styled-components';
-import * as theme from './theme.js';
+
 
 // ---------------- <AjaxLoader /> --------------------------------------
 
@@ -54,12 +55,12 @@ export const TileWrapper = styled.div`
     .source {
         font-size: .9em;
         padding: 1.25em;
-        color: ${theme.colorLightText};
+        color: ${props => props.theme.colorLightText};
 
         a {
             cursor: pointer;
             text-decoration: none;
-            color: ${theme.colorLogoBlue};
+            color: ${props => props.theme.colorLogoBlue};
         }
 
         a:hover {
@@ -78,7 +79,7 @@ export const TileWrapper = styled.div`
                 display: flex;
                 flex-grow: 1;
                 margin: 0;
-                color: ${theme.colorSuperlightGrey};
+                color: ${props => props.theme.colorSuperlightGrey};
                 font-size: 9em;
                 text-align: center;
                 justify-content: center;
@@ -94,8 +95,8 @@ export const TileWrapper = styled.div`
     hr {
         border: none;
         height: 2px;
-        color: ${theme.colorWhitelikeBlue};
-        background-color: ${theme.colorWhitelikeBlue};
+        color: ${props => props.theme.colorWhitelikeBlue};
+        background-color: ${props => props.theme.colorWhitelikeBlue};
     }
 `;
 
@@ -118,7 +119,7 @@ export const TitleLoaderBar = styled.div`
         margin-left: -110%;
         width: 100%;
         height: 0.2em;
-        background: linear-gradient(0.25turn, #ffffff, ${theme.colorLogoPink}, #ffffff);
+        background: linear-gradient(0.25turn, #ffffff, ${(props:{theme:Theme}) => props.theme.colorLogoPink}, #ffffff);
     }
 `;
 
@@ -130,7 +131,7 @@ export const HorizontalBlockSwitch = styled.div`
     text-align: center;
 
     a {
-        color: ${theme.colorLogoBlue};
+        color: ${props => props.theme.colorLogoBlue};
         cursor: pointer;
         font-size: 2em;
         padding: 0.2em;
@@ -142,7 +143,7 @@ export const HorizontalBlockSwitch = styled.div`
     }
 
     a.current {
-        color: ${theme.colorLogoBlueShining};
+        color: ${props => props.theme.colorLogoBlueShining};
     }
 `;
 
@@ -223,7 +224,7 @@ export const ModalOverlay = styled.div`
     }
 
 
-    ${theme.media.medium} {
+    ${props => props.theme.cssMediaMediumSize} {
         display: flex;
         align-items: center;
         justify-content: center;
@@ -270,7 +271,7 @@ export const ModalOverlay = styled.div`
         }
     }
 
-    ${theme.media.small} {
+    ${props => props.theme.cssMediaSmallSize} {
         background-color: hsla(0,0%,8%,.7);
 
         .box {
@@ -294,11 +295,11 @@ export const ModalOverlay = styled.div`
 
 // ---------------- <WdgTooltip /> --------------------------------------
 
-export const WdgTooltip = styled.div<{$multiword?:boolean}>`
+export const WdgTooltip = styled.div<{$multiword?:boolean, theme:Theme}>`
     background-color: #FFFFFF;
     z-index: 10000;
     padding: ${props => props.$multiword ? '0.3em 1em 1.3em 1em' : '1em'};
-    border: 1px solid ${theme.colorLightGrey};
+    border: 1px solid ${props => props.theme.colorInvertedSecondaryText};
     border-radius: 3px;
     border-spacing: 0;
     border-collapse: collapse;
@@ -349,14 +350,14 @@ export const WdgTooltip = styled.div<{$multiword?:boolean}>`
 
 // ---------------- <BacklinkForm /> --------------------------------------
 
-export const BacklinkButton = styled.button<{$createStaticUrl: (file:string) => string}>`
+export const BacklinkButton = styled.button<{$createStaticUrl: (file:string) => string, theme:Theme}>`
     display: inline;
     padding: 0 12px 0 0;
     border: none;
     background-color: transparent;
     cursor: pointer;
     text-decoration: none;
-    color: #009ee0;
+    color: ${props => props.theme.colorLogoBlue};
     background-image: url(${props => props.$createStaticUrl('external-link.svg')});
     background-repeat: no-repeat;
     background-position: 99% 0;
@@ -368,7 +369,7 @@ export const BacklinkButton = styled.button<{$createStaticUrl: (file:string) => 
 
 // ---------------- <SourceInfoBox /> --------------------------------------
 
-export const SourceInfoBox = styled.div<{$createStaticUrl: (file:string) => string}>`
+export const SourceInfoBox = styled.div<{theme:Theme, $createStaticUrl: (file:string) => string}>`
     font-size: 1.1em;
 
     ul.information-tab-sel {
@@ -384,14 +385,14 @@ export const SourceInfoBox = styled.div<{$createStaticUrl: (file:string) => stri
             font-size: 1em;
 
             a {
-                color: ${theme.colorDefaultText};
+                color: ${props => props.theme.colorDefaultText};
                 cursor: pointer;
                 margin: 0 0.6em;
                 text-decoration: none;
             }
 
             a.current {
-                border-color: ${theme.colorLogoBlue};
+                border-color: ${props => props.theme.colorLogoBlue};
                 border-style: solid;
                 border-width: 0 0 2px 0;
             }
@@ -406,7 +407,7 @@ export const SourceInfoBox = styled.div<{$createStaticUrl: (file:string) => stri
         th {
             text-align: left;
             font-weight: normal;
-            color: ${theme.colorLogoPink};
+            color: ${props => props.theme.colorLogoPink};
         }
     }
 
@@ -421,8 +422,8 @@ export const SourceInfoBox = styled.div<{$createStaticUrl: (file:string) => stri
 
         dt {
             margin-bottom: 0.4em;
-            color: ${theme.colorLightText};
-            font-family: ${theme.condensedFontFamily};
+            color: ${props => props.theme.colorLightText};
+            font-family: ${props => props.theme.condensedFontFamily};
         }
 
         dd {
@@ -445,7 +446,7 @@ export const SourceInfoBox = styled.div<{$createStaticUrl: (file:string) => stri
 
     .keyword {
         border-style: solid;
-        border-color: ${theme.colorLogoBlue};
+        border-color: ${props => props.theme.colorLogoBlue};
         border-width: 1pt;
         border-radius: 5px;
         margin: 0.4em 0.2em;
@@ -455,11 +456,11 @@ export const SourceInfoBox = styled.div<{$createStaticUrl: (file:string) => stri
 
     .citation {
         em {
-            color: ${theme.colorLogoPink};
+            color: ${props => props.theme.colorLogoPink};
         }
 
         a {
-            color: ${theme.colorLogoBlue};
+            color: ${props => props.theme.colorLogoBlue};
         }
     }
 

--- a/src/js/views/common/theme.tsx
+++ b/src/js/views/common/theme.tsx
@@ -32,7 +32,7 @@ export const colorDataHighlightRow = '#cdf0fe';
 export const colorLogoGreen = '#53a82c';
 export const colorWhitelikeBlue = '#eff9fe';
 export const colorLogoOrange = '#EA670C';
-export const colorLightGrey = '#dadada';
+export const colorInvertedSecondary = '#dadada';
 export const colorLightText = '#888888';
 export const colorSuperlightGrey = '#efefef';
 export const colorDefaultText = '#010101';
@@ -44,12 +44,13 @@ export const closeButtonSize = '1.1em';
 
 //
 
-export const defaultBorderStyle = `solid 1px ${colorLightGrey}`;
+export const defaultBorderStyle = `solid 1px ${colorInvertedSecondary}`;
 export const defaultBorderRadius = '0.25em';
 
 // media queries
 
 export const media = {
-   small: '@media screen and (max-width: 480px)',
-   medium: '@media screen and (max-width: 1200px)'
+    small: '@media screen and (max-width: 480px)',
+    medium: '@media screen and (max-width: 1200px)'
 }
+

--- a/src/js/views/layout/layout.tsx
+++ b/src/js/views/layout/layout.tsx
@@ -21,13 +21,14 @@ import * as React from 'react';
 import { resolve as urlResolve } from 'url';
 
 import { HostPageEnv, AvailableLanguage } from '../../page/hostPage.js';
-import { findCurrQueryMatch, QueryType, RecognizedQueries } from '../../query/index.js';
-import { ClientConf, UserConf, ColorThemeIdent, UserQuery } from '../../conf/index.js';
+import { RecognizedQueries } from '../../query/index.js';
+import { ClientConf, UserConf, ColorThemeIdent } from '../../conf/index.js';
 import { TileGroup } from '../../page/layout.js';
 import { GlobalComponents } from '../common/index.js';
 import { WdglanceMainProps } from '../main.js';
 import { ErrPageProps } from '../error.js';
 import { List, pipe } from 'cnc-tskit';
+import { Theme } from '../../page/theme.js';
 
 
 
@@ -72,10 +73,11 @@ function marshalJSON(data:any):string {
 
 
 export function init(
-    ut:ViewUtils<GlobalComponents>
+    ut:ViewUtils<GlobalComponents>,
+    theme:Theme
 ):{
-    HtmlBody: React.FC<HtmlBodyProps>;
-    HtmlHead: React.FC<HtmlHeadProps>
+    HtmlBody:React.FC<HtmlBodyProps>;
+    HtmlHead:React.FC<HtmlHeadProps>;
 } {
 
     // -------- <ThemeSelection /> -----------------------------
@@ -166,7 +168,7 @@ export function init(
                         </a>
                 </span>
                 {props.config.logo ?
-                    <span><img src={ut.createStaticUrl('logo-small.svg')} className="logo" alt="WaG" /></span> :
+                    <span><img className="filtered logo" src={ut.createStaticUrl('logo-small.svg')} alt="WaG installation logo" /></span> :
                     null
                 }
                 <span>{ut.translate('global__powered_by_wag_{version}', {version: props.version})}</span>
@@ -240,7 +242,7 @@ export function init(
                     <div className="parent-link-wrapper">
                         {props.currentParentWagPageUrl ?
                             <a className="parent-wag-link" href={props.currentParentWagPageUrl}>
-                                <img src={ut.createStaticUrl('triangle_left.svg')} />
+                                <img  className="filtered" src={ut.createStaticUrl('triangle_left.svg')} />
                                 {ut.translate('global__back_to_main_overview')}
                             </a> :
                             null
@@ -249,8 +251,8 @@ export function init(
                     <div className="logo-wrapper">
                         <a href={props.config.parentWagUrl ?  props.config.parentWagUrl : props.config.hostUrl} title={createLabel()}>
                             {props.config.logo?.url ?
-                                <img src={props.config.logo.url} alt="logo" style={props.config.logo?.inlineStyle} /> :
-                                <img src={ut.createStaticUrl(ut.translate('global__logo_file'))} alt="logo" />
+                                <img className="logo-filtered" src={props.config.logo.url} alt="logo" style={props.config.logo?.inlineStyle} /> :
+                                <img className="logo-filtered" src={ut.createStaticUrl(ut.translate('global__logo_file'))} alt="logo" />
                             }
                         </a>
                         {

--- a/src/js/views/layout/style.tsx
+++ b/src/js/views/layout/style.tsx
@@ -19,17 +19,25 @@
  */
 
 import { createGlobalStyle } from 'styled-components';
-import * as theme from '../common/theme.js';
-import grooveBg from '../../../../assets/groovepaper2.jpg';
+import { Theme } from '../../page/theme.js';
 
 // ---------------- <GlobalStyle /> --------------------------------------
 
-export const GlobalStyle = createGlobalStyle<{createStaticUrl: (file: string) => string}>`
+export const GlobalStyle = (confTheme:Theme) => createGlobalStyle<{createStaticUrl: (file: string) => string}>`
 
     body {
-        font-family: ${theme.defaultFontFamily};
-        font-size: 1em;
-        background-image: url(${grooveBg});
+        font-family: ${confTheme.defaultFontFamily};
+        font-size: ${confTheme.defaultFontSize};
+        background-image: ${confTheme.backgroundImage};
+        background-color: ${confTheme.pageBackgroundColor};
+
+        img.filtered {
+            ${confTheme.svgIconsFilter};
+        }
+
+        .logo-wrapper img.logo-filtered {
+            ${confTheme.svgIconsFilter};
+        }
 
         > header.wdg-header {
 
@@ -57,7 +65,7 @@ export const GlobalStyle = createGlobalStyle<{createStaticUrl: (file: string) =>
                 .parent-wag-link {
                     display: flex;
                     align-items: center;
-                    color: ${theme.colorLogoBlue};
+                    color: ${confTheme.colorLogoBlue};
                     text-decoration: underline;
                     cursor: pointer;
 
@@ -100,7 +108,7 @@ export const GlobalStyle = createGlobalStyle<{createStaticUrl: (file: string) =>
         border-collapse: collapse;
 
         tbody tr:nth-child(odd):not(.heading) {
-            background-color: ${theme.colorWhitelikeBlue};
+            background-color: ${confTheme.colorWhitelikeBlue};
         }
 
         tr.top-grouped th {
@@ -139,19 +147,19 @@ export const GlobalStyle = createGlobalStyle<{createStaticUrl: (file: string) =>
     }
 
     .note {
-        color: ${theme.colorLightText};
+        color: ${confTheme.colorLightText};
     }
 
     footer {
         font-size: 0.9em;
         text-align: center;
         margin-top: 1.5em;
-        color: ${theme.colorLightText};
+        color: ${confTheme.colorLightText};
 
         section {
             > span {
                 border-style: solid;
-                border-color: ${theme.colorLightText};
+                border-color: ${confTheme.colorLightText};
                 border-width: 0 0 0 0.15em;
                 padding-left: 0.4em;
                 padding-right: 0.4em;
@@ -168,17 +176,17 @@ export const GlobalStyle = createGlobalStyle<{createStaticUrl: (file: string) =>
 
         section.links > span:first-child {
             border-style: solid;
-            border-color: ${theme.colorLightText};
+            border-color: ${confTheme.colorLightText};
             border-width: 0 0 0 0.15em;
         }
 
         a {
-            color: ${theme.colorLightText};
+            color: ${confTheme.colorLightText};
             text-decoration: none;
         }
 
         .action a {
-            color: ${theme.colorDefaultText};
+            color: ${confTheme.colorDefaultText};
         }
 
         a:hover {
@@ -204,7 +212,7 @@ export const GlobalStyle = createGlobalStyle<{createStaticUrl: (file: string) =>
 
     .ThemeSelection {
         display: block;
-        color: ${theme.colorLightText};
+        color: ${confTheme.colorLightText};
 
         button {
             display: inline-block;
@@ -217,13 +225,13 @@ export const GlobalStyle = createGlobalStyle<{createStaticUrl: (file: string) =>
         }
 
         button.current {
-            color: ${theme.colorLogoBlue};
+            color: ${confTheme.colorLogoBlue};
             cursor: default;
         }
     }
 
     .LangSwitchToolbar {
-        color: ${theme.colorLightText};
+        color: ${confTheme.colorLightText};
         text-align: right;
         font-size: 0.9em;
 
@@ -240,19 +248,19 @@ export const GlobalStyle = createGlobalStyle<{createStaticUrl: (file: string) =>
                     border: none;
                     background-color: transparent;
                     cursor: pointer;
-                    color: ${theme.colorLightText};
+                    color: ${confTheme.colorLightText};
                     padding: 0 0.2em;
                 }
 
                 button:hover {
-                    color: ${theme.colorLogoBlue};
+                    color: ${confTheme.colorLogoBlue};
                 }
 
                 button.current {
                     text-decoration: none;
                     border-style: solid;
                     border-width: 0 0 1px 0;
-                    border-color: ${theme.colorLogoBlue};
+                    border-color: ${confTheme.colorLogoBlue};
                 }
             }
 
@@ -274,11 +282,11 @@ export const GlobalStyle = createGlobalStyle<{createStaticUrl: (file: string) =>
         .raw-html {
 
             em {
-                color: ${theme.colorLogoPink};
+                color: ${confTheme.colorLogoPink};
             }
 
             a {
-                color: ${theme.colorLogoBlue};
+                color: ${confTheme.colorLogoBlue};
             }
 
             a:hover {
@@ -304,9 +312,9 @@ export const GlobalStyle = createGlobalStyle<{createStaticUrl: (file: string) =>
     .cnc-tile {
         border-radius: .25em;
         box-shadow: .05em .05em .15em .05em rgba(0, 0, 0, 0.2);
-        background-color: white;
+        background-color: ${confTheme.tileBackgroundColor};
         font-size: .92em;
-        color: #333;
+        color: ${confTheme.colorSecondaryText};
     }
 
     .cnc-tile.highlighted {
@@ -321,7 +329,7 @@ export const GlobalStyle = createGlobalStyle<{createStaticUrl: (file: string) =>
     }
 
     .cnc-tile-body a {
-        color: #009ee0;
+        color: ${confTheme.colorLogoBlue};
         text-decoration: none;
     }
 
@@ -442,7 +450,7 @@ export const GlobalStyle = createGlobalStyle<{createStaticUrl: (file: string) =>
     .cnc-form input[type=email]:focus,
     .cnc-form textarea:focus,
     .cnc-form select:focus {
-        border-color: #009ee0;
+        background-color: ${confTheme.colorLogoBlue};
     }
 
     a.cnc-button.cnc-button {
@@ -455,8 +463,8 @@ export const GlobalStyle = createGlobalStyle<{createStaticUrl: (file: string) =>
     }
 
     .cnc-button.cnc-button-primary {
-        background-color: #009ee0;
-        color: white;
+        background-color: ${confTheme.colorLogoBlue};
+        color: ${confTheme.colorInvertText};
     }
 
     .cnc-button.cnc-button-primary:hover {
@@ -477,7 +485,7 @@ export const GlobalStyle = createGlobalStyle<{createStaticUrl: (file: string) =>
     }
 
 
-    ${theme.media.medium} {
+    ${confTheme.cssMediaMediumSize} {
 
         body {
             > header.wdg-header {
@@ -504,7 +512,7 @@ export const GlobalStyle = createGlobalStyle<{createStaticUrl: (file: string) =>
         }
     }
 
-    ${theme.media.small} {
+    ${confTheme.cssMediaSmallSize} {
 
         body > header.wdg-header a img {
             width: 15em;

--- a/src/js/views/main.tsx
+++ b/src/js/views/main.tsx
@@ -32,11 +32,13 @@ import { WdglanceTilesModel, WdglanceTilesState, TileResultFlagRec, blinkAndDehi
 import { init as corpusInfoViewInit } from './common/corpusInfo.js';
 import { GlobalComponents } from './common/index.js';
 import { fromEvent, timer } from 'rxjs';
+import { ThemeProvider } from 'styled-components';
 
 import * as S from './style.js';
-import * as SC from './common/style.js';
+import * as CS from './common/style.js';
 import { GlobalStyle } from './layout/style.js';
 import { MainPosAttrValues, TranslatLanguage, UserQuery } from '../conf/index.js';
+import { Theme } from '../page/theme.js';
 
 
 export interface WdglanceMainProps {
@@ -47,7 +49,7 @@ export interface WdglanceMainProps {
     isMobile:boolean;
     isAnswerMode:boolean;
     error:[number, string]|null;
-    onMount:()=>void
+    onMount:()=>void;
 }
 
 function mkTileSectionId(tileId:number):string {
@@ -60,11 +62,13 @@ export function init(
     ut:ViewUtils<GlobalComponents>,
     formModel:QueryFormModel,
     tilesModel:WdglanceTilesModel,
-    messagesModel:MessagesModel
+    messagesModel:MessagesModel,
+    dynamicTheme:Theme
 ):React.FC<WdglanceMainProps> {
 
     const globalComponents = ut.getComponents();
     const CorpusInfo = corpusInfoViewInit(dispatcher, ut);
+    const GlobalStyleWithDynamicTheme = GlobalStyle(dynamicTheme);
 
     // ------------------ <SystemMessage /> ------------------------------
 
@@ -106,7 +110,7 @@ export function init(
                         <p className="text">{props.text}</p>
                         <div className="close">
                             <a onClick={handleCloseClick}>
-                                <img src={ut.createStaticUrl('close-icon.svg')} alt={ut.translate('global__img_alt_close_icon')} />
+                                <img className="filtered" src={ut.createStaticUrl('close-icon.svg')} alt={ut.translate('global__img_alt_close_icon')} />
                             </a>
                         </div>
                     </div>
@@ -578,7 +582,7 @@ export function init(
         return (
             <span className="HelpButton bar-button">
                 <button type="button" onClick={handleClick} title={ut.translate('global__show_tile_help')}>
-                    <img src={ut.createStaticUrl('question-mark.svg')}
+                    <img className="filtered" src={ut.createStaticUrl('question-mark.svg')}
                         alt={ut.translate('global__img_alt_question_mark')} />
                 </button>
             </span>
@@ -624,6 +628,7 @@ export function init(
             <span className="AltViewButton bar-button">
                 <button type="button" onClick={handleClick} title={label}>
                     <img
+                        className="filtered"
                         src={isAltView ? lightIcon : icon}
                         alt={ut.translate('global__img_alt_alt_view')}
                         style={inlineCss} />
@@ -663,7 +668,7 @@ export function init(
         return (
             <span className="TweakButton bar-button">
                 <button type="button" onClick={handleClick} title={props.isExtended ? ut.translate('global__reset_size') : ut.translate('global__tweak')}>
-                    <img src={ut.createStaticUrl(props.isExtended ? 'config-icon_s.svg' : 'config-icon.svg')}
+                    <img className="filtered" src={ut.createStaticUrl(props.isExtended ? 'config-icon_s.svg' : 'config-icon.svg')}
                         alt={props.isExtended ? 'configuration icon (highlighted)' : 'configuration icon'} />
                 </button>
             </span>
@@ -690,7 +695,7 @@ export function init(
         return (
             <span className="SaveButton bar-button">
                 <button type="button" onClick={handleClick} title={ut.translate('global__save_svg')}>
-                    <img src={props.disabled ? ut.createStaticUrl('download-button_g.svg') : ut.createStaticUrl('download-button.svg')} alt={'download button'} />
+                    <img className="filtered" src={props.disabled ? ut.createStaticUrl('download-button_g.svg') : ut.createStaticUrl('download-button.svg')} alt={'download button'} />
                 </button>
             </span>
         );
@@ -764,7 +769,7 @@ export function init(
         reason:string;
 
     }> = (props) => (
-        <SC.TileWrapper className="empty">
+        <CS.TileWrapper className="empty">
             <div className="loader-wrapper"></div>
             <div className="cnc-tile-body content empty">
                 <div className="not-applicable-box">
@@ -777,7 +782,7 @@ export function init(
                     <p className="not-applicable" title={ut.translate('global__not_applicable')}><span>N/A</span></p>
                 </div>
             </div>
-        </SC.TileWrapper>
+        </CS.TileWrapper>
     );
 
 
@@ -909,8 +914,8 @@ export function init(
                     <span className="flex">
                     <span className={`triangle${props.groupHidden ? ' right' : ''}`}>
                                 {props.groupHidden ?
-                                    <img src={ut.createStaticUrl('triangle_w_right.svg')} alt={ut.translate('global__img_alt_triangle_w_right')} /> :
-                                    <img src={ut.createStaticUrl('triangle_w_down.svg')} alt={ut.translate('global__img_alt_triangle_w_down')} />
+                                    <img className="filtered" src={ut.createStaticUrl('triangle_w_right.svg')} alt={ut.translate('global__img_alt_triangle_w_right')} /> :
+                                    <img className="filtered" src={ut.createStaticUrl('triangle_w_down.svg')} alt={ut.translate('global__img_alt_triangle_w_down')} />
                                 }
                             </span>
                         <a className="switch-common" onClick={props.groupDisabled ? null : ()=>props.clickHandler()}
@@ -1003,7 +1008,7 @@ export function init(
                     <S.Tiles>
                         <section className="cnc-tile app-output" style={{gridColumn: 'span 3'}}>
                             <div className="provider">
-                                <SC.TileWrapper>
+                                <CS.TileWrapper>
                                     <div className="cnc-tile-body content empty">
                                         <div className="message">
                                             <globalComponents.MessageStatusIcon statusType={SystemMessageType.WARNING} isInline={false} />
@@ -1012,7 +1017,7 @@ export function init(
                                             </p>
                                         </div>
                                     </div>
-                                </SC.TileWrapper>
+                                </CS.TileWrapper>
                             </div>
                         </section>
                     </S.Tiles>
@@ -1347,10 +1352,12 @@ export function init(
 
         return (
             <S.WdglanceMain>
-                <GlobalStyle createStaticUrl={ut.createStaticUrl} />
-                <WdglanceControlsBound isMobile={props.isMobile} isAnswerMode={props.isAnswerMode} />
-                <BoundMessagesBox />
-                <BoundTilesSections layout={props.layout} homepageSections={props.homepageSections} />
+                <GlobalStyleWithDynamicTheme createStaticUrl={ut.createStaticUrl} />
+                <ThemeProvider theme={dynamicTheme}>
+                    <WdglanceControlsBound isMobile={props.isMobile} isAnswerMode={props.isAnswerMode} />
+                    <BoundMessagesBox />
+                    <BoundTilesSections layout={props.layout} homepageSections={props.homepageSections} />
+                </ThemeProvider>
             </S.WdglanceMain>
         );
     }

--- a/src/js/views/style.tsx
+++ b/src/js/views/style.tsx
@@ -19,7 +19,7 @@
  */
 
 import { styled } from 'styled-components';
-import * as theme from './common/theme.js';
+import { Theme } from '../page/theme.js';
 
 // ---------------- <WdglanceMain /> --------------------------------------
 
@@ -47,7 +47,7 @@ export const Messages = styled.ul`
 
 // ---------------- <SystemMessage /> --------------------------------------
 
-export const SystemMessage = styled.li`
+export const SystemMessage = styled.li<{theme:Theme}>`
     background-color: #444444;
     border-radius: .25em;
     box-shadow: 0.05em 0.05em 0.15em 0.05em rgba(0,0,0, 0.2);
@@ -109,7 +109,7 @@ export const SystemMessage = styled.li`
 
 // ---------------- <WdglanceControls /> --------------------------------------
 
-export const WdglanceControls = styled.div`
+export const WdglanceControls = styled.div<{theme:Theme}>`
     text-align: center;
     padding: 1em;
 
@@ -120,7 +120,7 @@ export const WdglanceControls = styled.div`
 
         .curr {
             font-size: 125%;
-            color: ${theme.colorLogoPink};
+            color: ${props => props.theme.colorLogoPink};
         }
 
         .variants > ul {
@@ -135,7 +135,7 @@ export const WdglanceControls = styled.div`
                 display: inline-block;
 
                 a {
-                    color: ${theme.colorLogoBlue};
+                    color: ${props => props.theme.colorLogoBlue};
                     cursor: pointer;
                 }
 
@@ -147,7 +147,7 @@ export const WdglanceControls = styled.div`
 
         a.modal-box-trigger {
             cursor: pointer;
-            color: ${theme.colorLogoPink};
+            color: ${props => props.theme.colorLogoPink};
         }
     }
 
@@ -178,7 +178,7 @@ export const WdglanceControls = styled.div`
 
                 em {
                     font-style: normal;
-                    color: ${theme.colorLogoPink};
+                    color: ${props => props.theme.colorLogoPink};
                 }
 
                 input[type="radio"] {
@@ -224,14 +224,14 @@ export const WdglanceControls = styled.div`
             }
 
             a:hover {
-                color: ${theme.colorLogoBlue};
+                color: ${props => props.theme.colorLogoBlue};
             }
 
         }
 
         .item.current {
             border-style: solid;
-            border-color: ${theme.colorLogoBlue};
+            border-color: ${props => props.theme.colorLogoBlue};
             border-width: 0 0 2px 0;
         }
     }
@@ -257,7 +257,7 @@ export const WdglanceControls = styled.div`
     }
 
     .QueryInput.invalid {
-        border-color: ${theme.colorLogoOrange};
+        border-color: ${props => props.theme.colorLogoOrange};
     }
 
     .input-group .input-row:not(:last-child) {
@@ -322,7 +322,7 @@ export const WdglanceControls = styled.div`
         }
     }
 
-    ${theme.media.medium} {
+    ${props => props.theme.cssMediaMediumSize} {
         .main {
             flex-wrap: wrap;
 
@@ -354,7 +354,7 @@ export const WdglanceControls = styled.div`
 
             .item.current {
                 border: none;
-                color: ${theme.colorLogoBlue};
+                color: ${props => props.theme.colorLogoBlue};
             }
 
             .item.current a:after {
@@ -371,7 +371,7 @@ export const WdglanceControls = styled.div`
         }
     }
 
-    ${theme.media.small} {
+    ${props => props.theme.cssMediaSmallSize} {
         padding: 0;
         margin-bottom: 2em;
 
@@ -387,9 +387,9 @@ export const WdglanceControls = styled.div`
 
 // -------------- <SubmitButton /> -------------------------------------------
 
-export const SubmitButton = styled.span`
+export const SubmitButton = styled.span<{theme:Theme}>`
 
-    ${theme.media.small} {
+    ${props => props.theme.cssMediaSmallSize} {
         button {
             padding: 0.5em 1.5em 0.5em 1.5em;
         }
@@ -418,7 +418,7 @@ export const TooManyErrorsBox = styled(NothingFoundBox)`
 
 // ---------------- <TilesSections /> --------------------------------------
 
-export const TilesSections = styled.section`
+export const TilesSections = styled.section<{theme:Theme}>`
     padding: 0.7em;
 
     & > header .loader {
@@ -426,18 +426,18 @@ export const TilesSections = styled.section`
         left: calc(100% - 100px);
     }
 
-    ${theme.media.medium} {
+    ${props => props.theme.cssMediaMediumSize} {
         padding: 0;
     }
 
-    ${theme.media.small} {
+    ${props => props.theme.cssMediaSmallSize} {
         padding: 0;
     }
 `;
 
 // ---------------- <Group /> --------------------------------------
 
-export const Group = styled.section`
+export const Group = styled.section<{theme:Theme}>`
 
     & > header {
 
@@ -454,7 +454,7 @@ export const Group = styled.section`
         margin-top: 1.7em;
     }
 
-    ${theme.media.medium} {
+    ${props => props.theme.cssMediaMediumSize} {
         & > header {
             display: block;
 
@@ -464,7 +464,7 @@ export const Group = styled.section`
         }
     }
 
-    ${theme.media.small} {
+    ${props => props.theme.cssMediaSmallSize} {
         & > header {
             display: block;
 
@@ -478,7 +478,7 @@ export const Group = styled.section`
 
 // ---------------- <MinimizedGroup /> --------------------------------------
 
-export const MinimizedGroup = styled.ul`
+export const MinimizedGroup = styled.ul<{theme:Theme}>`
     background-color: #FFFFFF;
     border-radius: 0.25em;
 
@@ -488,7 +488,7 @@ export const MinimizedGroup = styled.ul`
 
     li {
         a {
-            color: ${theme.colorLogoBlue};
+            color: ${props => props.theme.colorLogoBlue};
             cursor: pointer;
         }
     }
@@ -500,7 +500,7 @@ export const MinimizedGroup = styled.ul`
 
 // ---------------- <Tiles /> --------------------------------------
 
-export const Tiles = styled.section`
+export const Tiles = styled.section<{theme:Theme}>`
     display: grid;
     grid-gap: 1em;
     grid-template-columns: 1fr 1fr 1fr;
@@ -520,8 +520,8 @@ export const Tiles = styled.section`
     }
 
     .app-output {
-        border-color: ${theme.colorLogoBlue};
-        border-radius: ${theme.defaultBorderRadius};
+        border-color: ${props => props.theme.colorLogoBlue};
+        border-radius: ${props => props.theme.defaultBorderRadius};
         overflow: hidden;
         display: flex;
         flex-direction: column;
@@ -599,7 +599,7 @@ export const Tiles = styled.section`
         }
     }
 
-    ${theme.media.medium} {
+    ${props => props.theme.cssMediaMediumSize} {
         display: grid;
         grid-gap: 1em;
         grid-template-columns: 1fr;
@@ -625,7 +625,7 @@ export const Tiles = styled.section`
         }
     }
 
-    ${theme.media.small} {
+    ${props => props.theme.cssMediaSmallSize} {
         .app-output .panel h2 {
             font-size: 1.1em;
         }
@@ -634,14 +634,14 @@ export const Tiles = styled.section`
 
 // ---------------- <TileGroupButton /> --------------------------------------
 
-export const TileGroupButton = styled.section`
+export const TileGroupButton = styled.section<{theme:Theme}>`
 
     width: 25em;
 
     &.disabled {
 
         h2 {
-            background-color: ${theme.colorLightText};
+            background-color: ${props => props.theme.colorLightText};
 
             .flex {
 
@@ -661,8 +661,8 @@ export const TileGroupButton = styled.section`
     }
 
     h2 {
-        background-color: ${theme.colorLogoBlue};
-        color: #ffffff;
+        background-color: ${props => props.theme.colorLogoBlue};
+        color: ${props => props.theme.colorInvertText};
         border-radius: 0.25em;
         font-weight: 400;
         font-size: 1.3em;
@@ -693,7 +693,7 @@ export const TileGroupButton = styled.section`
             }
 
             a:hover {
-                color: ${theme.colorLogoBlueShining};
+                color: ${props => props.theme.colorLogoBlueShining};
             }
 
             .triangle {
@@ -728,7 +728,7 @@ export const TileGroupButton = styled.section`
         }
     }
 
-    ${theme.media.medium} {
+    ${props => props.theme.cssMediaMediumSize} {
 
         white-space: normal;
 
@@ -757,7 +757,7 @@ export const TileGroupButton = styled.section`
         }
     }
 
-    ${theme.media.small} {
+    ${props => props.theme.cssMediaSmallSize} {
 
         width: 100%;
         white-space: normal;
@@ -789,16 +789,16 @@ export const TileGroupButton = styled.section`
 
 // ---------------- <ErrPage /> --------------------------------------
 
-export const ErrPage = styled.div`
+export const ErrPage = styled.div<{theme:Theme}>`
     margin: 2em auto 3em auto;
     margin-bottom: 2em;
     max-width: 20em;
 
     header.err {
-        color: ${theme.colorLogoPink};
+        color: ${props => props.theme.colorLogoPink};
     }
 
     a {
-        color: ${theme.colorLogoBlue};
+        color: ${props => props.theme.colorLogoBlue};
     }
 `;


### PR DESCRIPTION
The current solution covers roughly 90% of WaG's visuals so there is still some work to do. But it is already possible to generate full-fledged themes.