### PR TITLE
Remove setting 'useDataStream' and also the arg for APIs of the ...

### DIFF
--- a/conf/themes-schema.json
+++ b/conf/themes-schema.json
@@ -116,6 +116,9 @@
                 "svgLogoFilter": {
                     "type": "string"
                 },
+                "textInputBackgroundColor": {
+                    "type": "string"
+                },
                 "themeId": {
                     "type": "string"
                 },
@@ -139,6 +142,9 @@
                     "type": "string"
                 },
                 "tileBorderStyle": {
+                    "type": "string"
+                },
+                "tileHeadingSeparColor": {
                     "type": "string"
                 }
             },

--- a/conf/tiles-schema.json
+++ b/conf/tiles-schema.json
@@ -18,9 +18,17 @@
             },
             "type": "object"
         },
-        "BacklinkConf<any>": {
+        "BacklinkConf": {
             "properties": {
-                "args": {},
+                "args": {
+                    "additionalProperties": {
+                        "type": [
+                            "string",
+                            "number"
+                        ]
+                    },
+                    "type": "object"
+                },
                 "label": {
                     "anyOf": [
                         {
@@ -47,7 +55,7 @@
             "description": "A configuration for a tile\nprovided by hosting page",
             "properties": {
                 "backlink": {
-                    "$ref": "#/definitions/BacklinkConf<any>",
+                    "$ref": "#/definitions/BacklinkConf",
                     "description": "An optional link to an application the specific tile\nrepresents (more or less). It is expected that the\ntile logic is able to pass proper arguments to the\npage."
                 },
                 "compatibleSubqProviders": {
@@ -100,9 +108,6 @@
                 "tileType": {
                     "description": "An identifier as defined by tiles configuration interface",
                     "type": "string"
-                },
-                "useDataStream": {
-                    "type": "boolean"
                 }
             },
             "required": [

--- a/conf/wdglance-schema.json
+++ b/conf/wdglance-schema.json
@@ -7,9 +7,17 @@
             },
             "type": "object"
         },
-        "BacklinkConf<any>": {
+        "BacklinkConf": {
             "properties": {
-                "args": {},
+                "args": {
+                    "additionalProperties": {
+                        "type": [
+                            "string",
+                            "number"
+                        ]
+                    },
+                    "type": "object"
+                },
                 "label": {
                     "anyOf": [
                         {
@@ -147,6 +155,9 @@
                 "svgLogoFilter": {
                     "type": "string"
                 },
+                "textInputBackgroundColor": {
+                    "type": "string"
+                },
                 "themeId": {
                     "type": "string"
                 },
@@ -170,6 +181,9 @@
                     "type": "string"
                 },
                 "tileBorderStyle": {
+                    "type": "string"
+                },
+                "tileHeadingSeparColor": {
                     "type": "string"
                 }
             },
@@ -30402,7 +30416,7 @@
             "description": "A configuration for a tile\nprovided by hosting page",
             "properties": {
                 "backlink": {
-                    "$ref": "#/definitions/BacklinkConf<any>",
+                    "$ref": "#/definitions/BacklinkConf",
                     "description": "An optional link to an application the specific tile\nrepresents (more or less). It is expected that the\ntile logic is able to pass proper arguments to the\npage."
                 },
                 "compatibleSubqProviders": {
@@ -30455,9 +30469,6 @@
                 "tileType": {
                     "description": "An identifier as defined by tiles configuration interface",
                     "type": "string"
-                },
-                "useDataStream": {
-                    "type": "boolean"
                 }
             },
             "required": [

--- a/launcher-config.json
+++ b/launcher-config.json
@@ -19,11 +19,11 @@
       "SERVER_CONF=${SERVER_CONF:-./conf/server.json}",
       "_CONFIG_PATH=\"$(node -pe '\"$CONFIG_PATH\" || \"./conf\"')\"",
       "ajv --allow-union-types --all-errors -s \"${_CONFIG_PATH}/server-schema.json\" -d ${SERVER_CONF}",
-      "ajv -s \"${_CONFIG_PATH}/wdglance-schema.json\" -d ./conf/wdglance.json",
+      "ajv --allow-union-types -s \"${_CONFIG_PATH}/wdglance-schema.json\" -d ./conf/wdglance.json",
       "LAYOUTS_PATH=\"$(node -pe 'JSON.parse(fs.readFileSync(process.env.CONFIG_PATH || \"./conf\" + \"/wdglance.json\", \"utf8\")).layouts')\"",
       "if test -f $LAYOUTS_PATH 2> /dev/null; then ajv -s ./conf/layouts-schema.json -d $LAYOUTS_PATH ; else echo \"layouts config file not found\"; fi",
       "TILES_PATH=\"$(node -pe 'JSON.parse(fs.readFileSync(process.env.CONFIG_PATH || \"./conf\" + \"/wdglance.json\", \"utf8\")).tiles')\"",
-      "if test -f $TILES_PATH 2> /dev/null; then ajv -s ./conf/tiles-schema.json -d $TILES_PATH ; else echo \"tiles config file not found\"; fi",
+      "if test -f $TILES_PATH 2> /dev/null; then ajv --allow-union-types -s ./conf/tiles-schema.json -d $TILES_PATH ; else echo \"tiles config file not found\"; fi",
       "THEMES_PATH=\"$(node -pe 'JSON.parse(fs.readFileSync(process.env.CONFIG_PATH || \"./conf\" + \"/wdglance.json\", \"utf8\")).colors')\"",
       "if test -f $THEMES_PATH 2> /dev/null; then ajv -s ./conf/themes-schema.json -d $THEMES_PATH ; else echo \"themes config file not found\"; fi",
       "DATA_READABILITY_PATH=\"$(node -pe 'JSON.parse(fs.readFileSync(process.env.CONFIG_PATH || \"./conf\" + \"/wdglance.json\", \"utf8\")).dataReadability')\"",
@@ -31,7 +31,7 @@
     ],
     "schemata:check-samples": [
       "ajv --allow-union-types --all-errors -s ./conf/server-schema.json -d ./conf/server.sample.json",
-      "ajv -s ./conf/wdglance-schema.json -d ./conf/wdglance.sample.json"
+      "ajv --allow-union-types -s ./conf/wdglance-schema.json -d ./conf/wdglance.sample.json"
     ],
     "build:production": [
       "typecheck:client",

--- a/src/js/api/vendor/mquery/freqs.ts
+++ b/src/js/api/vendor/mquery/freqs.ts
@@ -84,15 +84,12 @@ export class MQueryFreqDistribAPI implements ResourceApi<MQueryFreqArgs, APIResp
 
     private readonly srcInfoService:CorpusInfoAPI;
 
-    private readonly useDataStream:boolean;
-
     private readonly backlinkConf:BacklinkConf;
 
-    constructor(apiURL:string, apiServices:IApiServices, useDataStream:boolean, backlinkConf:BacklinkConf) {
+    constructor(apiURL:string, apiServices:IApiServices, backlinkConf:BacklinkConf) {
         this.apiURL = apiURL;
         this.apiServices = apiServices;
         this.srcInfoService = new CorpusInfoAPI(apiURL, apiServices);
-        this.useDataStream = useDataStream;
         this.backlinkConf = backlinkConf;
     }
 
@@ -123,9 +120,9 @@ export class MQueryFreqDistribAPI implements ResourceApi<MQueryFreqArgs, APIResp
      * For args.path == 'text-types', multiple values represent whole different thing
      * (freqs for different domains) - so in that case, we don't group anything.
      */
-    call(streaming:IDataStreaming, tileId:number, queryIdx:number, args:MQueryFreqArgs|null):Observable<APIResponse> {
+    call(streaming:IDataStreaming|null, tileId:number, queryIdx:number, args:MQueryFreqArgs|null):Observable<APIResponse> {
         return (
-            this.useDataStream ?
+            streaming ?
                 streaming.registerTileRequest<HTTPResponse>({
                     contentType: 'application/json',
                     body: {},

--- a/src/js/conf/preview.ts
+++ b/src/js/conf/preview.ts
@@ -39,13 +39,11 @@ const tileConf: {[name:string]:AnyPreviewTileConf} = {
         corpname: "ksp_2",
         corpusSize: 43224671,
         sfwRowRange: 7,
-        useDataStream: true,
     },
     PREVIEW__mergeCorpFreq: {
         tileType: "MergeCorpFreqTile",
         apiType: "mquery",
         apiURL: "/PREVIEW__mergeCorpFreq",
-        useDataStream: true,
         pixelsPerItem: 80,
         sources: [
             {
@@ -81,7 +79,6 @@ const tileConf: {[name:string]:AnyPreviewTileConf} = {
         tileType: "WordFormsTile",
         apiType: "mquery",
         apiURL: "/PREVIEW__wordForms",
-        useDataStream: true,
         label: {
             "cs-CZ": "Tvary",
             "en-US": "Forms"
@@ -89,6 +86,7 @@ const tileConf: {[name:string]:AnyPreviewTileConf} = {
         corpname: "syn2020",
         maxNumItems: 10,
         corpusSize: 150426,
+        posQueryGenerator: ["tag", "ppTagset"],
         freqFilterAlphaLevel: "0.05",
         helpURL: "---",
     },
@@ -96,7 +94,6 @@ const tileConf: {[name:string]:AnyPreviewTileConf} = {
         tileType: "CollocTile",
         apiType: "default",
         apiURL: "/PREVIEW__colloc",
-        useDataStream: true,
         corpname: "syn2020",
         minFreq: 5,
         minLocalFreq: 5,
@@ -115,7 +112,6 @@ const tileConf: {[name:string]:AnyPreviewTileConf} = {
         },
         pageSize: 10,
         posAttrs: ["word"],
-        useDataStream: true,
         sentenceStruct: "s",
         posQueryGenerator: [
             "tag",
@@ -128,7 +124,6 @@ const tileConf: {[name:string]:AnyPreviewTileConf} = {
         tileType: "TimeDistribTile",
         apiType: "mquery",
         apiURL: "/PREVIEW__timeDistrib",
-        useDataStream: true,
         corpname: "syn2020",
         subcname: ["9eSmyKII"],
         showMeasuredFreq: true,
@@ -150,7 +145,6 @@ const tileConf: {[name:string]:AnyPreviewTileConf} = {
     PREVIEW__freqBar: {
         tileType: "FreqBarTile",
         apiURL: "/PREVIEW__freqBar",
-        useDataStream: true,
         corpname: "oral_v1",
         fcrit: "sp.gender 0",
         freqType: "text-types",
@@ -174,7 +168,6 @@ const tileConf: {[name:string]:AnyPreviewTileConf} = {
         tileType: "SpeechesTile",
         apiType: "mquery",
         apiURL: "/PREVIEW__speeches",
-        useDataStream: true,
 
         audioPlaybackUrl: "/kontext/audio",
         helpURL: "/wag/static/help/czcorpus/missing.html",
@@ -192,7 +185,6 @@ const tileConf: {[name:string]:AnyPreviewTileConf} = {
         tileType: "GeoAreasTile",
         apiType: "mquery",
         apiURL: "/PREVIEW__geoAreas",
-        useDataStream: true,
 
         helpURL: "/wag/static/help/czcorpus/missing.html",
         corpname: "oral_v1",
@@ -224,7 +216,6 @@ const tileConf: {[name:string]:AnyPreviewTileConf} = {
     },
     PREVIEW__wordSim: {
         tileType: "WordSimTile",
-        useDataStream: true,
         apiURL: "/PREVIEW__wordSim",
         maxResultItems: 20,
         minMatchFreq: 0,
@@ -232,7 +223,6 @@ const tileConf: {[name:string]:AnyPreviewTileConf} = {
     PREVIEW__translations: {
         tileType: "TranslationsTile",
         apiURL: "/PREVIEW__translations",
-        useDataStream: true,
         primaryPackage: "CORE",
         srchPackages: {
             en: [
@@ -250,7 +240,6 @@ const tileConf: {[name:string]:AnyPreviewTileConf} = {
     PREVIEW__treqSubsets: {
         tileType: "TreqSubsetsTile",
         apiURL: "/PREVIEW__treqSubsets",
-        useDataStream: true,
         primaryPackage: "CORE",
         srchPackages: {
             en: [

--- a/src/js/conf/validation.ts
+++ b/src/js/conf/validation.ts
@@ -35,7 +35,7 @@ const SCHEMA_FILENAME = 'config-schema.json';
 
 
 export function validateTilesConf(tilesConf:AllQueryTypesTileConf):boolean {
-    const validator = new Ajv();
+    const validator = new Ajv({allowUnionTypes:true});
     let validationError = false;
     console.info('Validating tiles configuration...');
 

--- a/src/js/page/index.ts
+++ b/src/js/page/index.ts
@@ -160,9 +160,6 @@ export function initClient(
             null,
             pipe(
                 config.tiles,
-                Dict.filter(
-                    (v, k) => v.useDataStream
-                ),
                 Dict.keys(),
                 List.map(v => tileIdentMap[v])
             ),

--- a/src/js/page/tile.ts
+++ b/src/js/page/tile.ts
@@ -26,10 +26,10 @@ import { MainPosAttrValues } from '../conf/index.js';
 import { List } from 'cnc-tskit';
 
 
-export interface BacklinkConf<T = undefined> {
+export interface BacklinkConf {
     url:string;
     label?:LocalizedConfMsg;
-    args?:T;
+    args?:{[k:string]:number|string};
 }
 
 export interface Backlink {
@@ -70,7 +70,7 @@ export interface TileConf {
      * tile logic is able to pass proper arguments to the
      * page.
      */
-    backlink?:BacklinkConf<any>;
+    backlink?:BacklinkConf;
 
     /**
      * Normally, any tile configured in the "tiles" section
@@ -110,7 +110,6 @@ export interface TileConf {
      */
     compatibleSubqProviders?:Array<string>;
 
-    useDataStream?:boolean;
 }
 
 /**
@@ -330,8 +329,6 @@ export interface TileFactoryArgs<T> {
     conf:T;
 
     mainPosAttr:MainPosAttrValues;
-
-    useDataStream:boolean;
 
     dependentTiles:Array<number>;
 }

--- a/src/js/page/tileLoader.ts
+++ b/src/js/page/tileLoader.ts
@@ -114,7 +114,6 @@ export const mkTileFactory = (
                     conf,
                     isBusy: true,
                     mainPosAttr: layoutManager.getLayoutMainPosAttr(),
-                    useDataStream: !!conf.useDataStream,
                     dependentTiles: layoutManager.getDependentTiles(tileId)
                 };
                 const errs = tileFactory.sanityCheck(args);

--- a/src/js/tiles/core/colloc/config-schema.json
+++ b/src/js/tiles/core/colloc/config-schema.json
@@ -63,7 +63,7 @@
         },
         "backlink": {
             "description": "An optional link to an application the specific tile\nrepresents (more or less). It is expected that the\ntile logic is able to pass proper arguments to the\npage.",
-            "$ref": "#/definitions/BacklinkConf<any>"
+            "$ref": "#/definitions/BacklinkConf"
         },
         "isDisabled": {
             "description": "Normally, any tile configured in the \"tiles\" section\nwill be active no matter whether it is also in the\n\"layouts\" section. This allows e.g. a hidden concordance\ntile to ask for a concordance used by multiple visible\ntiles (e.g. colloc, freqs.). To be able to keep possibly\nusable items in the \"tiles\" configuration file it is\npossible to disable them. I.e. in case a tile is disabled\nit cannot be put in the layout without Wdglance complying\nabout invalid configuration.",
@@ -97,9 +97,6 @@
             "items": {
                 "type": "string"
             }
-        },
-        "useDataStream": {
-            "type": "boolean"
         }
     },
     "required": [
@@ -112,7 +109,7 @@
         "tileType"
     ],
     "definitions": {
-        "BacklinkConf<any>": {
+        "BacklinkConf": {
             "type": "object",
             "properties": {
                 "url": {
@@ -131,7 +128,15 @@
                         }
                     ]
                 },
-                "args": {}
+                "args": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": [
+                            "string",
+                            "number"
+                        ]
+                    }
+                }
             },
             "required": [
                 "url"

--- a/src/js/tiles/core/colloc/index.ts
+++ b/src/js/tiles/core/colloc/index.ts
@@ -72,7 +72,7 @@ export class CollocationsTile implements ITileProvider {
 
     constructor({
         tileId, dispatcher, appServices, ut, theme, widthFract, conf, isBusy,
-        queryMatches, queryType, useDataStream, dependentTiles, readDataFromTile
+        queryMatches, queryType, dependentTiles
     }:TileFactoryArgs<CollocationsTileConf>) {
 
         this.tileId = tileId;

--- a/src/js/tiles/core/colloc/views.tsx
+++ b/src/js/tiles/core/colloc/views.tsx
@@ -133,7 +133,7 @@ export function init(dispatcher:IActionDispatcher, ut:ViewUtils<GlobalComponents
                 return state.queryMatches[idx].word;
             }
         };
-
+        console.log('>>>>> state.backlinks: ', state.backlinks)
         return (
             <globalCompontents.TileWrapper tileId={props.tileId} isBusy={state.isBusy} error={state.error}
                     hasData={state.data.some(data => data !== null && data.length > 0)} sourceIdent={{corp: state.corpname}}

--- a/src/js/tiles/core/concordance/config-schema.json
+++ b/src/js/tiles/core/concordance/config-schema.json
@@ -115,7 +115,7 @@
         },
         "backlink": {
             "description": "An optional link to an application the specific tile\nrepresents (more or less). It is expected that the\ntile logic is able to pass proper arguments to the\npage.",
-            "$ref": "#/definitions/BacklinkConf<any>"
+            "$ref": "#/definitions/BacklinkConf"
         },
         "isDisabled": {
             "description": "Normally, any tile configured in the \"tiles\" section\nwill be active no matter whether it is also in the\n\"layouts\" section. This allows e.g. a hidden concordance\ntile to ask for a concordance used by multiple visible\ntiles (e.g. colloc, freqs.). To be able to keep possibly\nusable items in the \"tiles\" configuration file it is\npossible to disable them. I.e. in case a tile is disabled\nit cannot be put in the layout without Wdglance complying\nabout invalid configuration.",
@@ -149,9 +149,6 @@
             "items": {
                 "type": "string"
             }
-        },
-        "useDataStream": {
-            "type": "boolean"
         }
     },
     "required": [
@@ -163,7 +160,7 @@
         "tileType"
     ],
     "definitions": {
-        "BacklinkConf<any>": {
+        "BacklinkConf": {
             "type": "object",
             "properties": {
                 "url": {
@@ -182,7 +179,15 @@
                         }
                     ]
                 },
-                "args": {}
+                "args": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": [
+                            "string",
+                            "number"
+                        ]
+                    }
+                }
             },
             "required": [
                 "url"

--- a/src/js/tiles/core/freqBar/config-schema.json
+++ b/src/js/tiles/core/freqBar/config-schema.json
@@ -83,7 +83,7 @@
         },
         "backlink": {
             "description": "An optional link to an application the specific tile\nrepresents (more or less). It is expected that the\ntile logic is able to pass proper arguments to the\npage.",
-            "$ref": "#/definitions/BacklinkConf<any>"
+            "$ref": "#/definitions/BacklinkConf"
         },
         "isDisabled": {
             "description": "Normally, any tile configured in the \"tiles\" section\nwill be active no matter whether it is also in the\n\"layouts\" section. This allows e.g. a hidden concordance\ntile to ask for a concordance used by multiple visible\ntiles (e.g. colloc, freqs.). To be able to keep possibly\nusable items in the \"tiles\" configuration file it is\npossible to disable them. I.e. in case a tile is disabled\nit cannot be put in the layout without Wdglance complying\nabout invalid configuration.",
@@ -103,9 +103,6 @@
             "items": {
                 "type": "string"
             }
-        },
-        "useDataStream": {
-            "type": "boolean"
         }
     },
     "required": [
@@ -120,7 +117,7 @@
         "tileType"
     ],
     "definitions": {
-        "BacklinkConf<any>": {
+        "BacklinkConf": {
             "type": "object",
             "properties": {
                 "url": {
@@ -139,7 +136,15 @@
                         }
                     ]
                 },
-                "args": {}
+                "args": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": [
+                            "string",
+                            "number"
+                        ]
+                    }
+                }
             },
             "required": [
                 "url"

--- a/src/js/tiles/core/freqBar/index.ts
+++ b/src/js/tiles/core/freqBar/index.ts
@@ -22,7 +22,8 @@ import { LocalizedConfMsg } from '../../../types.js';
 import { findCurrQueryMatch, QueryType } from '../../../query/index.js';
 import {
     TileComponent, TileConf, TileFactory, ITileProvider, TileFactoryArgs,
-    DEFAULT_ALT_VIEW_ICON, ITileReloader, AltViewIconProps } from '../../../page/tile.js';
+    DEFAULT_ALT_VIEW_ICON, ITileReloader, AltViewIconProps,
+    BacklinkConf} from '../../../page/tile.js';
 import { GlobalComponents } from '../../../views/common/index.js';
 import { FreqBarModel } from './model.js';
 import { init as singleViewInit } from './views/single.js';
@@ -75,7 +76,7 @@ export class FreqBarTile implements ITileProvider {
 
     constructor({
         dispatcher, tileId, ut, theme, appServices, widthFract, conf, isBusy,
-        useDataStream, readDataFromTile, queryMatches, queryType
+        readDataFromTile, queryMatches, queryType
     }:TileFactoryArgs<FreqBarTileConf>) {
 
         this.dispatcher = dispatcher;
@@ -89,7 +90,7 @@ export class FreqBarTile implements ITileProvider {
             tileId,
             appServices,
             queryMatches: findCurrentMatches(queryMatches),
-            api: new MQueryFreqDistribAPI(conf.apiURL, appServices, useDataStream, conf.backlink),
+            api: new MQueryFreqDistribAPI(conf.apiURL, appServices, conf.backlink),
             readDataFromTile,
             initState: {
                 isBusy,

--- a/src/js/tiles/core/geoAreas/config-schema.json
+++ b/src/js/tiles/core/geoAreas/config-schema.json
@@ -72,7 +72,7 @@
         },
         "backlink": {
             "description": "An optional link to an application the specific tile\nrepresents (more or less). It is expected that the\ntile logic is able to pass proper arguments to the\npage.",
-            "$ref": "#/definitions/BacklinkConf<any>"
+            "$ref": "#/definitions/BacklinkConf"
         },
         "isDisabled": {
             "description": "Normally, any tile configured in the \"tiles\" section\nwill be active no matter whether it is also in the\n\"layouts\" section. This allows e.g. a hidden concordance\ntile to ask for a concordance used by multiple visible\ntiles (e.g. colloc, freqs.). To be able to keep possibly\nusable items in the \"tiles\" configuration file it is\npossible to disable them. I.e. in case a tile is disabled\nit cannot be put in the layout without Wdglance complying\nabout invalid configuration.",
@@ -106,9 +106,6 @@
             "items": {
                 "type": "string"
             }
-        },
-        "useDataStream": {
-            "type": "boolean"
         }
     },
     "required": [
@@ -125,7 +122,7 @@
         "tileType"
     ],
     "definitions": {
-        "BacklinkConf<any>": {
+        "BacklinkConf": {
             "type": "object",
             "properties": {
                 "url": {
@@ -144,7 +141,15 @@
                         }
                     ]
                 },
-                "args": {}
+                "args": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": [
+                            "string",
+                            "number"
+                        ]
+                    }
+                }
             },
             "required": [
                 "url"

--- a/src/js/tiles/core/geoAreas/index.ts
+++ b/src/js/tiles/core/geoAreas/index.ts
@@ -78,7 +78,7 @@ export class GeoAreasTile implements ITileProvider {
             tileId,
             appServices,
             queryMatches,
-            freqApi: new MQueryFreqDistribAPI(conf.apiURL, appServices, conf.useDataStream, conf.backlink),
+            freqApi: new MQueryFreqDistribAPI(conf.apiURL, appServices, conf.backlink),
             mapLoader: new MapLoader(appServices),
             queryType,
             initState: {

--- a/src/js/tiles/core/html/config-schema.json
+++ b/src/js/tiles/core/html/config-schema.json
@@ -39,7 +39,7 @@
         },
         "backlink": {
             "description": "An optional link to an application the specific tile\nrepresents (more or less). It is expected that the\ntile logic is able to pass proper arguments to the\npage.",
-            "$ref": "#/definitions/BacklinkConf<any>"
+            "$ref": "#/definitions/BacklinkConf"
         },
         "isDisabled": {
             "description": "Normally, any tile configured in the \"tiles\" section\nwill be active no matter whether it is also in the\n\"layouts\" section. This allows e.g. a hidden concordance\ntile to ask for a concordance used by multiple visible\ntiles (e.g. colloc, freqs.). To be able to keep possibly\nusable items in the \"tiles\" configuration file it is\npossible to disable them. I.e. in case a tile is disabled\nit cannot be put in the layout without Wdglance complying\nabout invalid configuration.",
@@ -73,9 +73,6 @@
             "items": {
                 "type": "string"
             }
-        },
-        "useDataStream": {
-            "type": "boolean"
         }
     },
     "required": [
@@ -106,7 +103,7 @@
             ],
             "type": "string"
         },
-        "BacklinkConf<any>": {
+        "BacklinkConf": {
             "type": "object",
             "properties": {
                 "url": {
@@ -125,7 +122,15 @@
                         }
                     ]
                 },
-                "args": {}
+                "args": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": [
+                            "string",
+                            "number"
+                        ]
+                    }
+                }
             },
             "required": [
                 "url"

--- a/src/js/tiles/core/mergeCorpFreq/api.ts
+++ b/src/js/tiles/core/mergeCorpFreq/api.ts
@@ -69,8 +69,6 @@ export class MergeFreqsApi implements ResourceApi<Array<MQueryFreqArgs>, Array<S
 
     private readonly apiURL:string;
 
-    private readonly useDataStream:boolean;
-
     private readonly apiServices:IApiServices;
 
     private readonly backlinkConf:BacklinkConf;
@@ -79,13 +77,12 @@ export class MergeFreqsApi implements ResourceApi<Array<MQueryFreqArgs>, Array<S
 
     private freqApi:MQueryFreqDistribAPI;
 
-    constructor(apiURL:string, useDataStream:boolean, apiServices:IApiServices, backlinkConf:BacklinkConf) {
+    constructor(apiURL:string, apiServices:IApiServices, backlinkConf:BacklinkConf) {
         this.apiURL = apiURL;
-        this.useDataStream = useDataStream;
         this.apiServices = apiServices;
         this.backlinkConf = backlinkConf;
         this.srcInfoService = new CorpusInfoAPI(apiURL, apiServices);
-        this.freqApi = new MQueryFreqDistribAPI(this.apiURL, this.apiServices, this.useDataStream, this.backlinkConf);
+        this.freqApi = new MQueryFreqDistribAPI(this.apiURL, this.apiServices, this.backlinkConf);
     }
 
     private prepareArgs(queryArgs:MQueryFreqArgs):string {

--- a/src/js/tiles/core/mergeCorpFreq/config-schema.json
+++ b/src/js/tiles/core/mergeCorpFreq/config-schema.json
@@ -121,7 +121,7 @@
         },
         "backlink": {
             "description": "An optional link to an application the specific tile\nrepresents (more or less). It is expected that the\ntile logic is able to pass proper arguments to the\npage.",
-            "$ref": "#/definitions/BacklinkConf<any>"
+            "$ref": "#/definitions/BacklinkConf"
         },
         "isDisabled": {
             "description": "Normally, any tile configured in the \"tiles\" section\nwill be active no matter whether it is also in the\n\"layouts\" section. This allows e.g. a hidden concordance\ntile to ask for a concordance used by multiple visible\ntiles (e.g. colloc, freqs.). To be able to keep possibly\nusable items in the \"tiles\" configuration file it is\npossible to disable them. I.e. in case a tile is disabled\nit cannot be put in the layout without Wdglance complying\nabout invalid configuration.",
@@ -155,9 +155,6 @@
             "items": {
                 "type": "string"
             }
-        },
-        "useDataStream": {
-            "type": "boolean"
         }
     },
     "required": [
@@ -167,7 +164,7 @@
         "tileType"
     ],
     "definitions": {
-        "BacklinkConf<any>": {
+        "BacklinkConf": {
             "type": "object",
             "properties": {
                 "url": {
@@ -186,7 +183,15 @@
                         }
                     ]
                 },
-                "args": {}
+                "args": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": [
+                            "string",
+                            "number"
+                        ]
+                    }
+                }
             },
             "required": [
                 "url"

--- a/src/js/tiles/core/mergeCorpFreq/index.ts
+++ b/src/js/tiles/core/mergeCorpFreq/index.ts
@@ -115,7 +115,7 @@ export class MergeCorpFreqTile implements ITileProvider {
             dispatcher: this.dispatcher,
             tileId,
             appServices,
-            freqApi: new MergeFreqsApi(conf.apiURL, conf.useDataStream, appServices, conf.backlink),
+            freqApi: new MergeFreqsApi(conf.apiURL, appServices, conf.backlink),
             initState: {
                 isBusy: isBusy,
                 isAltViewMode: false,

--- a/src/js/tiles/core/speeches/api.ts
+++ b/src/js/tiles/core/speeches/api.ts
@@ -77,19 +77,16 @@ export class SpeechesApi implements ResourceApi<SpeechReqArgs, SpeechData> {
 
     private readonly apiUrl:string;
 
-    private readonly useDataStream:boolean;
-
     private readonly srcInfoService:CorpusInfoAPI;
 
     private readonly apiServices:IApiServices;
 
     private readonly backlinkConf:BacklinkConf;
 
-    constructor(apiUrl:string, useDataStream:boolean, apiServices:IApiServices, backlinkConf:BacklinkConf) {
+    constructor(apiUrl:string, apiServices:IApiServices, backlinkConf:BacklinkConf) {
         this.apiUrl = apiUrl;
         this.srcInfoService = new CorpusInfoAPI(apiUrl, apiServices);
         this.apiServices = apiServices;
-        this.useDataStream = useDataStream;
         this.backlinkConf = backlinkConf;
     }
 
@@ -110,7 +107,7 @@ export class SpeechesApi implements ResourceApi<SpeechReqArgs, SpeechData> {
     }
 
     call(dataStreaming:IDataStreaming, tileId:number, queryIdx:number, args:SpeechReqArgs|null):Observable<SpeechData> {
-        if (this.useDataStream) {
+        if (dataStreaming) {
             return dataStreaming.registerTileRequest<SpeechResponse>(
                 {
                     tileId,

--- a/src/js/tiles/core/speeches/config-schema.json
+++ b/src/js/tiles/core/speeches/config-schema.json
@@ -104,7 +104,7 @@
         },
         "backlink": {
             "description": "An optional link to an application the specific tile\nrepresents (more or less). It is expected that the\ntile logic is able to pass proper arguments to the\npage.",
-            "$ref": "#/definitions/BacklinkConf<any>"
+            "$ref": "#/definitions/BacklinkConf"
         },
         "isDisabled": {
             "description": "Normally, any tile configured in the \"tiles\" section\nwill be active no matter whether it is also in the\n\"layouts\" section. This allows e.g. a hidden concordance\ntile to ask for a concordance used by multiple visible\ntiles (e.g. colloc, freqs.). To be able to keep possibly\nusable items in the \"tiles\" configuration file it is\npossible to disable them. I.e. in case a tile is disabled\nit cannot be put in the layout without Wdglance complying\nabout invalid configuration.",
@@ -138,9 +138,6 @@
             "items": {
                 "type": "string"
             }
-        },
-        "useDataStream": {
-            "type": "boolean"
         }
     },
     "required": [
@@ -154,7 +151,7 @@
         "tileType"
     ],
     "definitions": {
-        "BacklinkConf<any>": {
+        "BacklinkConf": {
             "type": "object",
             "properties": {
                 "url": {
@@ -173,7 +170,15 @@
                         }
                     ]
                 },
-                "args": {}
+                "args": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": [
+                            "string",
+                            "number"
+                        ]
+                    }
+                }
             },
             "required": [
                 "url"

--- a/src/js/tiles/core/speeches/index.ts
+++ b/src/js/tiles/core/speeches/index.ts
@@ -71,7 +71,7 @@ export class SpeechesTile implements ITileProvider {
             dispatcher,
             tileId,
             appServices,
-            api: new SpeechesApi(conf.apiURL, conf.useDataStream, appServices, conf.backlink),
+            api: new SpeechesApi(conf.apiURL, appServices, conf.backlink),
             audioLinkGenerator: conf.audioApiURL ?
                 new AudioLinkGenerator(conf.audioApiURL) :
                 null,

--- a/src/js/tiles/core/syntacticColls/api/scollex.ts
+++ b/src/js/tiles/core/syntacticColls/api/scollex.ts
@@ -61,18 +61,15 @@ export class ScollexSyntacticCollsAPI implements ResourceApi<SCollsRequest, SCol
 
     private readonly apiURL:string;
 
-    private readonly useDataStream:boolean;
-
     private readonly apiServices:IApiServices;
 
     private readonly srcInfoService:CorpusInfoAPI;
 
     private readonly backlinkConf:BacklinkConf;
 
-    constructor(apiURL:string, useDataStream:boolean, apiServices:IApiServices, backlinkConf:BacklinkConf) {
+    constructor(apiURL:string, apiServices:IApiServices, backlinkConf:BacklinkConf) {
         this.apiURL = apiURL;
         this.apiServices = apiServices;
-        this.useDataStream = useDataStream;
         this.backlinkConf = backlinkConf;
         this.srcInfoService = new CorpusInfoAPI(apiURL, apiServices);
     }
@@ -86,10 +83,10 @@ export class ScollexSyntacticCollsAPI implements ResourceApi<SCollsRequest, SCol
         return null;
     }
 
-    call(dataStreaming:IDataStreaming, tileId:number, queryIdx:number, request:SCollsRequest):Observable<SCollsData> {
+    call(dataStreaming:IDataStreaming|null, tileId:number, queryIdx:number, request:SCollsRequest):Observable<SCollsData> {
         const url = urlJoin(this.apiURL, 'query', request.params.corpname, request.params.queryType);
         let data:Observable<SCollsApiResponse>;
-        if (this.useDataStream) {
+        if (dataStreaming) {
             data = dataStreaming.registerTileRequest<SCollsApiResponse>(
                 {
                     tileId,

--- a/src/js/tiles/core/syntacticColls/api/wsserver.ts
+++ b/src/js/tiles/core/syntacticColls/api/wsserver.ts
@@ -60,14 +60,11 @@ export class WSServerSyntacticCollsAPI implements DataApi<SCollsRequest, SCollsD
 
     private readonly apiURL:string;
 
-    private readonly useDataStream:boolean;
-
     private readonly apiServices:IApiServices;
 
-    constructor(apiURL:string, useDataStream:boolean, apiServices:IApiServices) {
+    constructor(apiURL:string, apiServices:IApiServices) {
         this.apiURL = apiURL;
         this.apiServices = apiServices;
-        this.useDataStream = useDataStream;
     }
 
     private mkUrl(request:SCollsRequest):string {

--- a/src/js/tiles/core/syntacticColls/config-schema.json
+++ b/src/js/tiles/core/syntacticColls/config-schema.json
@@ -55,7 +55,7 @@
         },
         "backlink": {
             "description": "An optional link to an application the specific tile\nrepresents (more or less). It is expected that the\ntile logic is able to pass proper arguments to the\npage.",
-            "$ref": "#/definitions/BacklinkConf<any>"
+            "$ref": "#/definitions/BacklinkConf"
         },
         "isDisabled": {
             "description": "Normally, any tile configured in the \"tiles\" section\nwill be active no matter whether it is also in the\n\"layouts\" section. This allows e.g. a hidden concordance\ntile to ask for a concordance used by multiple visible\ntiles (e.g. colloc, freqs.). To be able to keep possibly\nusable items in the \"tiles\" configuration file it is\npossible to disable them. I.e. in case a tile is disabled\nit cannot be put in the layout without Wdglance complying\nabout invalid configuration.",
@@ -89,9 +89,6 @@
             "items": {
                 "type": "string"
             }
-        },
-        "useDataStream": {
-            "type": "boolean"
         }
     },
     "required": [
@@ -194,7 +191,7 @@
                 "sentenceStruct"
             ]
         },
-        "BacklinkConf<any>": {
+        "BacklinkConf": {
             "type": "object",
             "properties": {
                 "url": {
@@ -213,7 +210,15 @@
                         }
                     ]
                 },
-                "args": {}
+                "args": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": [
+                            "string",
+                            "number"
+                        ]
+                    }
+                }
             },
             "required": [
                 "url"

--- a/src/js/tiles/core/syntacticColls/index.ts
+++ b/src/js/tiles/core/syntacticColls/index.ts
@@ -140,8 +140,8 @@ export class SyntacticCollsTile implements ITileProvider {
             queryType: queryType,
             maxItems: conf.maxItems,
             api: conf.apiType === 'wss' ?
-                new WSServerSyntacticCollsAPI(conf.apiURL, conf.useDataStream, appServices) :
-                new ScollexSyntacticCollsAPI(conf.apiURL, conf.useDataStream, appServices, conf.backlink),
+                new WSServerSyntacticCollsAPI(conf.apiURL, appServices) :
+                new ScollexSyntacticCollsAPI(conf.apiURL, appServices, conf.backlink),
             eApi: new SyntacticCollsExamplesAPI(conf.eApiURL, appServices, conf.attrNames),
             initState: {
                 isBusy: isBusy,

--- a/src/js/tiles/core/syntacticCollsVsTextTypes/api.ts
+++ b/src/js/tiles/core/syntacticCollsVsTextTypes/api.ts
@@ -84,18 +84,15 @@ export class WSServerSyntacticCollsTTAPI implements DataApi<SCollsRequest, SColl
 
     private readonly apiURL:string;
 
-    private readonly useDataStream:boolean;
-
     private readonly apiServices:IApiServices;
 
     private readonly srcInfoService:CorpusInfoAPI;
 
     private readonly backlinkConf:BacklinkConf;
 
-    constructor(apiURL:string, useDataStream:boolean, apiServices:IApiServices, backlinkConf:BacklinkConf) {
+    constructor(apiURL:string, apiServices:IApiServices, backlinkConf:BacklinkConf) {
         this.apiURL = apiURL;
         this.apiServices = apiServices;
-        this.useDataStream = useDataStream;
         this.backlinkConf = backlinkConf;
         this.srcInfoService = new CorpusInfoAPI(apiURL, apiServices);
     }

--- a/src/js/tiles/core/syntacticCollsVsTextTypes/config-schema.json
+++ b/src/js/tiles/core/syntacticCollsVsTextTypes/config-schema.json
@@ -45,7 +45,7 @@
         },
         "backlink": {
             "description": "An optional link to an application the specific tile\nrepresents (more or less). It is expected that the\ntile logic is able to pass proper arguments to the\npage.",
-            "$ref": "#/definitions/BacklinkConf<any>"
+            "$ref": "#/definitions/BacklinkConf"
         },
         "isDisabled": {
             "description": "Normally, any tile configured in the \"tiles\" section\nwill be active no matter whether it is also in the\n\"layouts\" section. This allows e.g. a hidden concordance\ntile to ask for a concordance used by multiple visible\ntiles (e.g. colloc, freqs.). To be able to keep possibly\nusable items in the \"tiles\" configuration file it is\npossible to disable them. I.e. in case a tile is disabled\nit cannot be put in the layout without Wdglance complying\nabout invalid configuration.",
@@ -79,9 +79,6 @@
             "items": {
                 "type": "string"
             }
-        },
-        "useDataStream": {
-            "type": "boolean"
         }
     },
     "required": [
@@ -156,7 +153,7 @@
                 "sentenceStruct"
             ]
         },
-        "BacklinkConf<any>": {
+        "BacklinkConf": {
             "type": "object",
             "properties": {
                 "url": {
@@ -175,7 +172,15 @@
                         }
                     ]
                 },
-                "args": {}
+                "args": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": [
+                            "string",
+                            "number"
+                        ]
+                    }
+                }
             },
             "required": [
                 "url"

--- a/src/js/tiles/core/syntacticCollsVsTextTypes/index.ts
+++ b/src/js/tiles/core/syntacticCollsVsTextTypes/index.ts
@@ -78,7 +78,7 @@ export class SyntacticCollsVsTextTypesTile implements ITileProvider {
             queryType: queryType,
             maxItems: conf.maxItems,
             theme,
-            api: new WSServerSyntacticCollsTTAPI(conf.apiURL, conf.useDataStream, appServices, conf.backlink),
+            api: new WSServerSyntacticCollsTTAPI(conf.apiURL, appServices, conf.backlink),
             eApi: new SyntacticCollsExamplesAPI(conf.eApiURL, appServices, conf.attrNames),
             initState: {
                 corpname: conf.corpname,

--- a/src/js/tiles/core/timeDistrib/config-schema.json
+++ b/src/js/tiles/core/timeDistrib/config-schema.json
@@ -81,7 +81,7 @@
         },
         "backlink": {
             "description": "An optional link to an application the specific tile\nrepresents (more or less). It is expected that the\ntile logic is able to pass proper arguments to the\npage.",
-            "$ref": "#/definitions/BacklinkConf<any>"
+            "$ref": "#/definitions/BacklinkConf"
         },
         "isDisabled": {
             "description": "Normally, any tile configured in the \"tiles\" section\nwill be active no matter whether it is also in the\n\"layouts\" section. This allows e.g. a hidden concordance\ntile to ask for a concordance used by multiple visible\ntiles (e.g. colloc, freqs.). To be able to keep possibly\nusable items in the \"tiles\" configuration file it is\npossible to disable them. I.e. in case a tile is disabled\nit cannot be put in the layout without Wdglance complying\nabout invalid configuration.",
@@ -115,9 +115,6 @@
             "items": {
                 "type": "string"
             }
-        },
-        "useDataStream": {
-            "type": "boolean"
         }
     },
     "required": [
@@ -129,7 +126,7 @@
         "tileType"
     ],
     "definitions": {
-        "BacklinkConf<any>": {
+        "BacklinkConf": {
             "type": "object",
             "properties": {
                 "url": {
@@ -148,7 +145,15 @@
                         }
                     ]
                 },
-                "args": {}
+                "args": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": [
+                            "string",
+                            "number"
+                        ]
+                    }
+                }
             },
             "required": [
                 "url"

--- a/src/js/tiles/core/translations/config-schema.json
+++ b/src/js/tiles/core/translations/config-schema.json
@@ -55,7 +55,7 @@
         },
         "backlink": {
             "description": "An optional link to an application the specific tile\nrepresents (more or less). It is expected that the\ntile logic is able to pass proper arguments to the\npage.",
-            "$ref": "#/definitions/BacklinkConf<any>"
+            "$ref": "#/definitions/BacklinkConf"
         },
         "isDisabled": {
             "description": "Normally, any tile configured in the \"tiles\" section\nwill be active no matter whether it is also in the\n\"layouts\" section. This allows e.g. a hidden concordance\ntile to ask for a concordance used by multiple visible\ntiles (e.g. colloc, freqs.). To be able to keep possibly\nusable items in the \"tiles\" configuration file it is\npossible to disable them. I.e. in case a tile is disabled\nit cannot be put in the layout without Wdglance complying\nabout invalid configuration.",
@@ -89,9 +89,6 @@
             "items": {
                 "type": "string"
             }
-        },
-        "useDataStream": {
-            "type": "boolean"
         }
     },
     "required": [
@@ -101,7 +98,7 @@
         "tileType"
     ],
     "definitions": {
-        "BacklinkConf<any>": {
+        "BacklinkConf": {
             "type": "object",
             "properties": {
                 "url": {
@@ -120,7 +117,15 @@
                         }
                     ]
                 },
-                "args": {}
+                "args": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": [
+                            "string",
+                            "number"
+                        ]
+                    }
+                }
             },
             "required": [
                 "url"

--- a/src/js/tiles/core/translations/index.ts
+++ b/src/js/tiles/core/translations/index.ts
@@ -67,7 +67,6 @@ export class TranslationsTile implements ITileProvider {
         this.model = new TranslationsModel({
             dispatcher,
             appServices,
-            useDataStreaming: conf.useDataStream,
             initialState: {
                 isBusy: isBusy,
                 isAltViewMode: false,

--- a/src/js/tiles/core/translations/model.ts
+++ b/src/js/tiles/core/translations/model.ts
@@ -34,7 +34,6 @@ export interface TranslationModelArgs {
     tileId:number;
     api:TreqAPI;
     queryMatches:RecognizedQueries;
-    useDataStreaming:boolean;
     scaleColorGen:ColorScaleFunctionGenerator;
 }
 
@@ -51,8 +50,6 @@ export class TranslationsModel extends StatelessModel<TranslationsModelState> {
 
     private readonly appServices:IAppServices;
 
-    private readonly useDataStreaming:boolean;
-
     constructor({
         dispatcher,
         appServices,
@@ -60,14 +57,12 @@ export class TranslationsModel extends StatelessModel<TranslationsModelState> {
         tileId,
         api,
         queryMatches,
-        useDataStreaming,
         scaleColorGen}:TranslationModelArgs) {
 
         super(dispatcher, initialState);
         this.api = api;
         this.queryMatches = queryMatches;
         this.tileId = tileId;
-        this.useDataStreaming = useDataStreaming;
         this.scaleColorGen = scaleColorGen;
         this.appServices = appServices;
 

--- a/src/js/tiles/core/treqSubsets/config-schema.json
+++ b/src/js/tiles/core/treqSubsets/config-schema.json
@@ -39,7 +39,7 @@
         },
         "backlink": {
             "description": "An optional link to an application the specific tile\nrepresents (more or less). It is expected that the\ntile logic is able to pass proper arguments to the\npage.",
-            "$ref": "#/definitions/BacklinkConf<any>"
+            "$ref": "#/definitions/BacklinkConf"
         },
         "isDisabled": {
             "description": "Normally, any tile configured in the \"tiles\" section\nwill be active no matter whether it is also in the\n\"layouts\" section. This allows e.g. a hidden concordance\ntile to ask for a concordance used by multiple visible\ntiles (e.g. colloc, freqs.). To be able to keep possibly\nusable items in the \"tiles\" configuration file it is\npossible to disable them. I.e. in case a tile is disabled\nit cannot be put in the layout without Wdglance complying\nabout invalid configuration.",
@@ -73,9 +73,6 @@
             "items": {
                 "type": "string"
             }
-        },
-        "useDataStream": {
-            "type": "boolean"
         }
     },
     "required": [
@@ -112,7 +109,7 @@
                 "packages"
             ]
         },
-        "BacklinkConf<any>": {
+        "BacklinkConf": {
             "type": "object",
             "properties": {
                 "url": {
@@ -131,7 +128,15 @@
                         }
                     ]
                 },
-                "args": {}
+                "args": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": [
+                            "string",
+                            "number"
+                        ]
+                    }
+                }
             },
             "required": [
                 "url"

--- a/src/js/tiles/core/wordForms/api/backlink.ts
+++ b/src/js/tiles/core/wordForms/api/backlink.ts
@@ -25,34 +25,32 @@ import { BacklinkConf } from "../../../../page/tile.js";
 import { IApiServices } from "../../../../appServices.js";
 import { CorpusInfoAPI } from "../../../../api/vendor/mquery/corpusInfo.js";
 
-export interface BacklinkConfArgs {
-    posQueryGenerator:[string, string];
-}
+
 
 export class WordFormsBacklinkAPI {
 
-    protected readonly apiURL;
-    
+    protected readonly apiURL:string;
+
     protected readonly apiServices:IApiServices;
 
     protected readonly srcInfoService:CorpusInfoAPI;
 
-    protected readonly useDataStream:boolean;
+    protected readonly backlinkConf:BacklinkConf;
 
-    protected readonly backlinkConf:BacklinkConf<BacklinkConfArgs>;
+    protected readonly posQueryGenerator:[string, string];
 
-    constructor(apiURL:string, useDataStream:boolean, apiServices:IApiServices, backlinkConf:BacklinkConf<BacklinkConfArgs>) {
+    constructor(apiURL:string, apiServices:IApiServices, posQueryGenerator:[string, string], backlinkConf:BacklinkConf) {
         this.apiURL = apiURL;
-        this.useDataStream = useDataStream;
         this.apiServices = apiServices;
         this.srcInfoService = new CorpusInfoAPI(apiURL, apiServices);
         this.backlinkConf = backlinkConf;
+        this.posQueryGenerator = posQueryGenerator;
     }
 
     requestBacklink(args:RequestArgs, queryMatch:QueryMatch):Observable<URL> {
         const concArgs = {
             corpname: args.corpName,
-            q: `q${mkLemmaMatchQuery(queryMatch, this.backlinkConf.args.posQueryGenerator)}`,
+            q: `q${mkLemmaMatchQuery(queryMatch, this.posQueryGenerator)}`,
             format: 'json',
         };
         return ajax$<{conc_persistence_op_id:string}>(

--- a/src/js/tiles/core/wordForms/api/frodo.ts
+++ b/src/js/tiles/core/wordForms/api/frodo.ts
@@ -52,9 +52,9 @@ export interface FrodoResponse {
 
 export class FrodoWordFormsAPI extends WordFormsBacklinkAPI implements ResourceApi<RequestArgs, Response> {
 
-    call(dataStreaming:IDataStreaming, tileId:number, queryIdx:number, args:RequestArgs):Observable<Response> {
+    call(dataStreaming:IDataStreaming|null, tileId:number, queryIdx:number, args:RequestArgs):Observable<Response> {
         const url = urlJoin(this.apiURL, '/dictionary/', args.corpName, 'search', args.lemma);
-        return (this.useDataStream ?
+        return (dataStreaming ?
             dataStreaming.registerTileRequest<FrodoResponse>(
                 {
                     tileId,

--- a/src/js/tiles/core/wordForms/api/mquery.ts
+++ b/src/js/tiles/core/wordForms/api/mquery.ts
@@ -49,9 +49,9 @@ export class MQueryWordFormsAPI extends WordFormsBacklinkAPI implements Resource
         )
     }
 
-    call(dataStreaming:IDataStreaming, tileId:number, queryIdx:number, args:RequestArgs):Observable<Response> {
+    call(dataStreaming:IDataStreaming|null, tileId:number, queryIdx:number, args:RequestArgs):Observable<Response> {
         const url = urlJoin(this.apiURL, '/word-forms/', args.corpName);
-        return (this.useDataStream ?
+        return (dataStreaming ?
             dataStreaming.registerTileRequest<Array<LemmaItem>>(
                 {
                     tileId,

--- a/src/js/tiles/core/wordForms/config-schema.json
+++ b/src/js/tiles/core/wordForms/config-schema.json
@@ -16,6 +16,19 @@
         "freqFilterAlphaLevel": {
             "$ref": "#/definitions/Maths.AlphaLevel"
         },
+        "posQueryGenerator": {
+            "type": "array",
+            "items": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "string"
+                }
+            ],
+            "minItems": 2,
+            "maxItems": 2
+        },
         "tileType": {
             "description": "An identifier as defined by tiles configuration interface",
             "type": "string"
@@ -36,7 +49,7 @@
         },
         "backlink": {
             "description": "An optional link to an application the specific tile\nrepresents (more or less). It is expected that the\ntile logic is able to pass proper arguments to the\npage.",
-            "$ref": "#/definitions/BacklinkConf<any>"
+            "$ref": "#/definitions/BacklinkConf"
         },
         "isDisabled": {
             "description": "Normally, any tile configured in the \"tiles\" section\nwill be active no matter whether it is also in the\n\"layouts\" section. This allows e.g. a hidden concordance\ntile to ask for a concordance used by multiple visible\ntiles (e.g. colloc, freqs.). To be able to keep possibly\nusable items in the \"tiles\" configuration file it is\npossible to disable them. I.e. in case a tile is disabled\nit cannot be put in the layout without Wdglance complying\nabout invalid configuration.",
@@ -70,9 +83,6 @@
             "items": {
                 "type": "string"
             }
-        },
-        "useDataStream": {
-            "type": "boolean"
         }
     },
     "required": [
@@ -81,6 +91,7 @@
         "corpname",
         "corpusSize",
         "freqFilterAlphaLevel",
+        "posQueryGenerator",
         "tileType"
     ],
     "definitions": {
@@ -92,7 +103,7 @@
             ],
             "type": "string"
         },
-        "BacklinkConf<any>": {
+        "BacklinkConf": {
             "type": "object",
             "properties": {
                 "url": {
@@ -111,7 +122,15 @@
                         }
                     ]
                 },
-                "args": {}
+                "args": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": [
+                            "string",
+                            "number"
+                        ]
+                    }
+                }
             },
             "required": [
                 "url"

--- a/src/js/tiles/core/wordForms/index.ts
+++ b/src/js/tiles/core/wordForms/index.ts
@@ -28,7 +28,6 @@ import { CoreApiGroup } from '../../../api/coreGroups.js';
 import { MQueryWordFormsAPI } from './api/mquery.js';
 import { IWordFormsApi } from './common.js';
 import { FrodoWordFormsAPI } from './api/frodo.js';
-import { BacklinkConfArgs } from './api/backlink.js';
 
 
 export interface WordFormsTileConf extends TileConf {
@@ -37,6 +36,7 @@ export interface WordFormsTileConf extends TileConf {
     corpname:string;
     corpusSize:number;
     freqFilterAlphaLevel:Maths.AlphaLevel;
+    posQueryGenerator:[string, string];
 }
 
 
@@ -56,7 +56,7 @@ export class WordFormsTile implements ITileProvider {
 
     constructor({
         tileId, dispatcher, appServices, ut, queryMatches, widthFract, conf, isBusy,
-        theme, mainPosAttr, useDataStream}:TileFactoryArgs<WordFormsTileConf>
+        theme, mainPosAttr}:TileFactoryArgs<WordFormsTileConf>
     ) {
 
         this.tileId = tileId;
@@ -78,22 +78,22 @@ export class WordFormsTile implements ITileProvider {
                 mainPosAttr
             },
             tileId,
-            api: this.createApi(conf.apiType, conf.apiURL, useDataStream, appServices, conf.backlink),
+            api: this.createApi(conf, appServices),
             queryMatches,
             appServices,
         });
         this.view = viewInit(dispatcher, ut, theme, this.model);
     }
 
-    private createApi(apiType:string, apiURL:string, useDataStream:boolean, appServices:IAppServices, backlinkConf:BacklinkConf<BacklinkConfArgs>):IWordFormsApi {
-        switch (apiType) {
+    private createApi(conf:WordFormsTileConf, appServices:IAppServices):IWordFormsApi {
+        switch (conf.apiType) {
             case CoreApiGroup.MQUERY:
-                return new MQueryWordFormsAPI(apiURL, useDataStream, appServices, backlinkConf);
+                return new MQueryWordFormsAPI(conf.apiURL, appServices, conf.posQueryGenerator, conf.backlink);
             case CoreApiGroup.FRODO:
-                return new FrodoWordFormsAPI(apiURL, useDataStream, appServices, backlinkConf);
+                return new FrodoWordFormsAPI(conf.apiURL, appServices, conf.posQueryGenerator, conf.backlink);
             case CoreApiGroup.KORPUS_DB:
             default:
-                throw new Error(`Unsupported API type: ${apiType}`);
+                throw new Error(`Unsupported API type: ${conf.apiType}`);
         }
     }
 

--- a/src/js/tiles/core/wordFreq/config-schema.json
+++ b/src/js/tiles/core/wordFreq/config-schema.json
@@ -45,7 +45,7 @@
         },
         "backlink": {
             "description": "An optional link to an application the specific tile\nrepresents (more or less). It is expected that the\ntile logic is able to pass proper arguments to the\npage.",
-            "$ref": "#/definitions/BacklinkConf<any>"
+            "$ref": "#/definitions/BacklinkConf"
         },
         "isDisabled": {
             "description": "Normally, any tile configured in the \"tiles\" section\nwill be active no matter whether it is also in the\n\"layouts\" section. This allows e.g. a hidden concordance\ntile to ask for a concordance used by multiple visible\ntiles (e.g. colloc, freqs.). To be able to keep possibly\nusable items in the \"tiles\" configuration file it is\npossible to disable them. I.e. in case a tile is disabled\nit cannot be put in the layout without Wdglance complying\nabout invalid configuration.",
@@ -79,9 +79,6 @@
             "items": {
                 "type": "string"
             }
-        },
-        "useDataStream": {
-            "type": "boolean"
         }
     },
     "required": [
@@ -106,7 +103,7 @@
                 "rel"
             ]
         },
-        "BacklinkConf<any>": {
+        "BacklinkConf": {
             "type": "object",
             "properties": {
                 "url": {
@@ -125,7 +122,15 @@
                         }
                     ]
                 },
-                "args": {}
+                "args": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": [
+                            "string",
+                            "number"
+                        ]
+                    }
+                }
             },
             "required": [
                 "url"

--- a/src/js/tiles/core/wordFreq/index.ts
+++ b/src/js/tiles/core/wordFreq/index.ts
@@ -59,7 +59,7 @@ export class WordFreqTile implements ITileProvider {
 
     constructor({
         tileId, dispatcher, appServices, ut, queryMatches, widthFract,
-        conf, isBusy, queryType, mainPosAttr, useDataStream, theme}:TileFactoryArgs<WordFreqTileConf>
+        conf, isBusy, queryType, mainPosAttr, theme}:TileFactoryArgs<WordFreqTileConf>
     ) {
         this.tileId = tileId;
         this.appServices = appServices;
@@ -82,8 +82,7 @@ export class WordFreqTile implements ITileProvider {
             tileId,
             api: new SimilarFreqWordsFrodoAPI(
                 queryType === QueryType.CMP_QUERY ? '' : conf.apiURL,
-                appServices,
-                useDataStream
+                appServices
             ),
             sourceInfoApi: new CorpusInfoAPI(conf.infoApiURL ? conf.infoApiURL : conf.apiURL, appServices),
             queryMatches: queryMatches,

--- a/src/js/tiles/core/wordFreq/similarFreq.ts
+++ b/src/js/tiles/core/wordFreq/similarFreq.ts
@@ -54,18 +54,15 @@ export class SimilarFreqWordsFrodoAPI {
 
     private readonly apiServices:IApiServices;
 
-    private readonly useDataStream:boolean;
-
-    constructor(apiURL:string, apiServices:IApiServices, useDataStream:boolean) {
+    constructor(apiURL:string, apiServices:IApiServices) {
         this.apiURL = apiURL;
         this.apiServices = apiServices;
-        this.useDataStream = useDataStream;
     }
 
-    call(dataStreaming:IDataStreaming, tileId:number, queryIdx:number, args:RequestArgs|null):Observable<Array<SimilarFreqWord>> {
+    call(dataStreaming:IDataStreaming|null, tileId:number, queryIdx:number, args:RequestArgs|null):Observable<Array<SimilarFreqWord>> {
         return (
-            this.useDataStream ?
-                this.apiServices.dataStreaming().registerTileRequest<HTTPResponse>(
+            dataStreaming ?
+                dataStreaming.registerTileRequest<HTTPResponse>(
                     {
                         contentType: 'application/json',
                         body: {},

--- a/src/js/tiles/core/wordSim/api/standard.ts
+++ b/src/js/tiles/core/wordSim/api/standard.ts
@@ -169,7 +169,6 @@ export class CNCWord2VecSimApi implements ResourceApi<CNCWord2VecSimApiArgs, Wor
 
     constructor(
         apiURL:string,
-        useDataStream:boolean,
         srcInfoURL:string,
         apiServices:IApiServices
     ) {

--- a/src/js/tiles/core/wordSim/api/wss.ts
+++ b/src/js/tiles/core/wordSim/api/wss.ts
@@ -51,7 +51,6 @@ export class CNCWSServerApi implements ResourceApi<CNCWord2VecSimApiArgs, WordSi
 
     constructor(
         apiURL:string,
-        useDataStream:boolean,
         srcInfoURL:string,
         apiServices:IApiServices
     ) {

--- a/src/js/tiles/core/wordSim/config-schema.json
+++ b/src/js/tiles/core/wordSim/config-schema.json
@@ -46,7 +46,7 @@
         },
         "backlink": {
             "description": "An optional link to an application the specific tile\nrepresents (more or less). It is expected that the\ntile logic is able to pass proper arguments to the\npage.",
-            "$ref": "#/definitions/BacklinkConf<any>"
+            "$ref": "#/definitions/BacklinkConf"
         },
         "isDisabled": {
             "description": "Normally, any tile configured in the \"tiles\" section\nwill be active no matter whether it is also in the\n\"layouts\" section. This allows e.g. a hidden concordance\ntile to ask for a concordance used by multiple visible\ntiles (e.g. colloc, freqs.). To be able to keep possibly\nusable items in the \"tiles\" configuration file it is\npossible to disable them. I.e. in case a tile is disabled\nit cannot be put in the layout without Wdglance complying\nabout invalid configuration.",
@@ -80,9 +80,6 @@
             "items": {
                 "type": "string"
             }
-        },
-        "useDataStream": {
-            "type": "boolean"
         }
     },
     "required": [
@@ -92,7 +89,7 @@
         "tileType"
     ],
     "definitions": {
-        "BacklinkConf<any>": {
+        "BacklinkConf": {
             "type": "object",
             "properties": {
                 "url": {
@@ -111,7 +108,15 @@
                         }
                     ]
                 },
-                "args": {}
+                "args": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": [
+                            "string",
+                            "number"
+                        ]
+                    }
+                }
             },
             "required": [
                 "url"

--- a/src/js/tiles/core/wordSim/index.ts
+++ b/src/js/tiles/core/wordSim/index.ts
@@ -63,7 +63,7 @@ export class WordSimTile implements ITileProvider {
 
     constructor({
         tileId, dispatcher, appServices, ut, widthFract, conf, theme,
-        isBusy, useDataStream, queryMatches}:TileFactoryArgs<WordSimTileConf>
+        isBusy, queryMatches}:TileFactoryArgs<WordSimTileConf>
     ) {
         this.tileId = tileId;
         this.dispatcher = dispatcher;
@@ -71,8 +71,8 @@ export class WordSimTile implements ITileProvider {
         this.widthFract = widthFract;
         this.label = appServices.importExternalMessage(conf.label || 'wordsim__main_label');
         this.api = conf.apiType === 'wss' ?
-            new CNCWSServerApi(conf.apiURL, useDataStream, conf.srcInfoURL, appServices) :
-            new CNCWord2VecSimApi(conf.apiURL, useDataStream, conf.srcInfoURL, appServices);
+            new CNCWSServerApi(conf.apiURL, conf.srcInfoURL, appServices) :
+            new CNCWord2VecSimApi(conf.apiURL, conf.srcInfoURL, appServices);
         this.model = new WordSimModel({
             appServices,
             dispatcher,


### PR DESCRIPTION
... same name. There is no use for that as wag2 is already tightly integrated with APIGuard and its data streaming.

We should also remove any unnecessary ajax variants in our api client code.